### PR TITLE
fix: update import paths from ui to shared directory

### DIFF
--- a/src/components/LocaleSelector.vue
+++ b/src/components/LocaleSelector.vue
@@ -2,7 +2,7 @@
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import LanguageIcon from '~icons/tabler/language'
-import CpMenu from '@/components/ui/CpMenu.vue'
+import CpMenu from '@/components/shared/CpMenu.vue'
 
 const router = useRouter()
 const { locale } = useI18n()

--- a/src/components/shared/CpMenu.vue
+++ b/src/components/shared/CpMenu.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import CpPopover from '@/components/ui/CpPopover.vue'
+import CpPopover from '@/components/shared/CpPopover.vue'
 
 interface Options {
   label: string


### PR DESCRIPTION
Updates import paths in `LocaleSelector.vue` and `CpMenu.vue` to reference the `shared` directory instead of the old `ui` directory, following the refactor in commit b5acb4f.