### PR TITLE
fix: align icons with text using vertical offset

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -35,6 +35,7 @@ export default defineNuxtConfig({
     customCollections: [
       { prefix: 'local', dir: './app/assets/icons' },
     ],
+    class: 'icon',
   },
 
   i18n: {

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -6,7 +6,9 @@ import { defineConfig, presetTypography } from 'unocss'
 import presetThemes from 'unocss-preset-theme'
 
 export default defineConfig({
-  mergeSelectors: true,
+  shortcuts: {
+    icon: '-align-0.125em',
+  },
   extractors: [
     extractorMdc(),
   ],


### PR DESCRIPTION
Fixes icon alignment issues where icons were not properly aligned with adjacent text.

### Changes

- Add `icon` class to Nuxt Icon module configuration
- Define `icon` shortcut in UnoCSS with `-align-0.125em` vertical offset
- This applies consistent vertical alignment to all icons (both local and remote collections)

### Technical Details

The negative vertical offset (`-align-0.125em`) ensures icons align properly with the baseline of surrounding text, improving visual consistency across the UI.