### PR TITLE
Add Early Bird CfP section to landing page

### DIFF
--- a/app/pages/landing.vue
+++ b/app/pages/landing.vue
@@ -31,7 +31,7 @@ definePageMeta({
       </p>
       <p>
         <NuxtLink
-          class="text-decoration-none text-white px-4 py-2 rounded bg-cp-green shadow hover:shadow-lg"
+          class="not-prose text-white px-4 py-2 rounded bg-cp-green shadow hover:shadow-lg"
           target="_blank"
           :to="`https://blog.coscup.org/2026/02/lead-trend-coscup-2026-early-bird-cfp.html#${t('early_bird_cfp.anchor')}`"
         >


### PR DESCRIPTION
- Add new Early Bird Call for Proposals section with i18n strings (en/zh) and a link to the blog post
- Extract sponsorship email from inline text into a clickable mailto link
- Adjust landing page spacing (`gap-12` → `gap-4`, add `px-4` padding)