### PR TITLE
fix: early bird CfP link i18n and build configuration

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -2,6 +2,9 @@ import { defineNuxtConfig } from 'nuxt/config'
 
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
+  compatibilityDate: '2025-07-15',
+  devtools: { enabled: true },
+
   app: {
     baseURL: '/2026/',
     head: {
@@ -16,9 +19,6 @@ export default defineNuxtConfig({
       publicDir: process.env.NUXT_OUTPUT_DIR || '.output/public',
     },
   },
-
-  compatibilityDate: '2025-07-15',
-  devtools: { enabled: true },
 
   imports: {
     scan: false,
@@ -59,5 +59,6 @@ export default defineNuxtConfig({
       { code: 'zh', name: '中文', language: 'zh-Hant-TW' },
     ],
     defaultLocale: 'zh',
+    detectBrowserLanguage: false, // https://github.com/nuxt-modules/i18n/issues/3262
   },
 })


### PR DESCRIPTION
- Disable `detectBrowserLanguage` to fix SSG hydration mismatch where the CfP anchor resolves to the wrong locale (`#cfp-zh` instead of `#cfp-en`) on first load after client-side redirect (nuxt-modules/i18n#3262)
- Make Nitro output directory configurable via `NUXT_OUTPUT_DIR` environment variable.
