### PR TITLE
feat: add Call for Participation section to landing page

### DIFF
--- a/app/pages/landing.vue
+++ b/app/pages/landing.vue
@@ -123,5 +123,5 @@ zh:
     title: "徵求社群參與"
     desc: "社群議程軌與社群攤位開放申請中，帶領您的社群參與 COSCUP 2026！"
     link_text: "瞭解更多"
-    anchor: ""
+    anchor: "Blog1"
 </i18n>


### PR DESCRIPTION
As requested in [Mattermost](https://chat.coscup.org/coscup/pl/ncsh9uri8tyrpc11ggkety3w9c):

> Hi ~web ，先 tag @mirumodapon @rileychh 兩位
> 要請你們協助修改 landing page：
> 增加「徵社群 / Call for Participation」連結在 https://coscup.org/2026/
> `https://blog.coscup.org/2026/02/coscup-2026-call-for-participation.html`
>
> 我們開始徵社群議程軌與社群攤位～～
>
> 感謝！