### PR TITLE
feat: add print-friendly styles to sponsorship page

### DIFF
--- a/app/pages/sponsorship.vue
+++ b/app/pages/sponsorship.vue
@@ -21,6 +21,7 @@ const about = await useLocaleContent('/sponsorship/about', locale, defaultLocale
 const tierLevels = TIER_LEVELS
 
 const tiersHint = computed(() => t('tiers.hint'))
+const addOnsHint = computed(() => t('addons.hint'))
 
 const addOnFigures = computed(() => [
   { src: '/sponsorship/flag.webp', alt: t('addons.flag') },
@@ -100,7 +101,12 @@ const addOnFigures = computed(() => [
     <h2 class="print:m-0 print:break-before-page">
       {{ t('addons.heading') }}
     </h2>
-    <p>{{ t('addons.hint') }}</p>
+    <p
+      v-if="addOnsHint"
+      class="print:break-after-avoid"
+    >
+      {{ addOnsHint }}
+    </p>
 
     <div class="overflow-x-auto">
       <table class="print:m-0">


### PR DESCRIPTION
## Summary

- Add print utility classes for better PDF/print output of the sponsorship page
- Reduce page margins, hide language switcher, prevent tier cards from breaking across pages
- Force add-ons section onto a new page and use 2-column grid for tiers and photos

Fixes #56
[sponsorship-zh.pdf](https://github.com/user-attachments/files/26347455/sponsorship-zh.pdf)
[sponsorship-en.pdf](https://github.com/user-attachments/files/26347464/sponsorship-en.pdf)

