### PR TITLE
Add CONTRIBUTING.md and deduplicate AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,6 @@ Follow @CONTRIBUTING.md for commit, branch, code style, and workflow conventions
 
 - `session/` — Fetches from Pretalx API
 - `sponsorship/` — Fetches from Google Sheets (CSV export)
-- `opass.get.ts` — OPass integration
+- `opass.json.get.ts` — OPass integration
 
 **Icons:** Custom icon collection in `app/assets/icons/`, referenced as `local:icon-name`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,18 +2,15 @@
 
 COSCUP 2026 conference website built with Nuxt 4, statically generated and deployed to GitHub Pages.
 
+Follow @CONTRIBUTING.md for commit, branch, code style, and workflow conventions.
+
 ## Architecture
 
 **Framework:** Nuxt 4 (Vue 3) with static generation, base URL `/2026/`.
 
-**Styling:** UnoCSS with Tailwind Wind4 preset. Theme colors: `primary-50` through `primary-800`, `cp-green`. No Tailwind CSS directly — use UnoCSS classes.
+**Styling:** UnoCSS with Tailwind Wind4 preset. Theme colors: `primary-50` through `primary-800`, `cp-green`.
 
-**i18n:** Two locales — `zh` (default, Traditional Chinese) and `en`. Translations live in two places:
-
-- `<i18n lang="yaml">` blocks inside Vue SFCs for UI strings
-- `content/{en,zh}/` directories for Markdown page content
-
-Content collections are defined in `content.config.ts` as `content_en` and `content_zh`. The `useLocaleContent` composable fetches the right locale's markdown and falls back to the default locale.
+**i18n:** Content collections are defined in `content.config.ts` as `content_en` and `content_zh`. The `useLocaleContent` composable fetches the right locale's markdown and falls back to the default locale.
 
 **Content pages:** `pages/[...slug].vue` is the catch-all that renders Markdown from `content/`. Custom MDC components (`app/components/content/`) like `LeafletMap`, `BusRoutes`, `Info`, and `Copyable` are auto-registered for use in Markdown.
 
@@ -21,19 +18,8 @@ Content collections are defined in `content.config.ts` as `content_en` and `cont
 
 **Server API:** Nitro server routes in `server/api/`:
 
-- `session/` — Fetches from Pretalx API (cached via `defineCachedFunction`)
+- `session/` — Fetches from Pretalx API
 - `sponsorship/` — Fetches from Google Sheets (CSV export)
 - `opass.get.ts` — OPass integration
 
-**Shared types:** `shared/types/` contains Zod schemas shared between server and client (e.g., sponsorship tier validation).
-
 **Icons:** Custom icon collection in `app/assets/icons/`, referenced as `local:icon-name`.
-
-## ESLint Conventions
-
-Uses `@antfu/eslint-config` with these notable rules:
-
-- Vue attributes must be alphabetical and one-per-line
-- `1tbs` brace style with `curly: multi-line, consistent`
-- Arrow functions always need parens: `(x) => x`
-- ESLint is the formatter — no Prettier

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Follow [Conventional Commits](https://www.conventionalcommits.org/):
 
 - `feat: add session detail page`
 - `fix(pretalx): handle empty speaker response`
-- `chore(i18n): add English translations for venue page`
+- `chore: add English translations for venue page`
 
 ## Branch Names
 
@@ -35,13 +35,13 @@ Use kebab-case: `add-session-page`, `fix-sponsor-logo`
 pnpm install    # install dependencies
 pnpm dev        # start dev server
 pnpm build      # static generation (nuxt generate)
-pnpm lint       # ESLint (also formats)
+pnpm lint       # ESLint (check only; append --fix to auto-fix)
 pnpm typecheck  # Vue type checking
 ```
 
 ## Code Style
 
-ESLint is the sole formatter — no Prettier. Run `pnpm lint` before committing. Fix formatting and lint errors in the same commit as the code change, not as a separate commit.
+ESLint is the sole formatter — no Prettier. Run `pnpm lint` before committing to check for errors, and `pnpm lint --fix` to auto-fix formatting and lint issues. Fix formatting and lint errors in the same commit as the code change, not as a separate commit.
 
 ## Auto-imports
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# Contributing
+
+## Commit Messages
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```text
+<type>[optional scope]: <description>
+```
+
+**Types:**
+
+- `feat` — end-user visible new functionality or behavior change
+- `fix` — end-user visible bug fixes
+- `refactor` — restructuring code without changing behavior
+- `chore` — dependency updates, config changes, i18n strings, other maintenance
+- `ci` — GitHub Actions workflows
+- `docs` — documentation only
+
+**Scopes:** `pretalx`, `sheets`, `opass`. Omit scope if not listed here.
+
+**Examples:**
+
+- `feat: add session detail page`
+- `fix(pretalx): handle empty speaker response`
+- `chore(i18n): add English translations for venue page`
+
+## Branch Names
+
+Use kebab-case: `add-session-page`, `fix-sponsor-logo`
+
+## Development
+
+```bash
+pnpm install    # install dependencies
+pnpm dev        # start dev server
+pnpm build      # static generation (nuxt generate)
+pnpm lint       # ESLint (also formats)
+pnpm typecheck  # Vue type checking
+```
+
+## Code Style
+
+ESLint is the sole formatter — no Prettier. Run `pnpm lint` before committing. Fix formatting and lint errors in the same commit as the code change, not as a separate commit.
+
+## Auto-imports
+
+Auto-import scanning is disabled (`imports: { scan: false }` in `nuxt.config.ts`). Composables and utilities from Vue, Nuxt, and other libraries are still auto-imported, but project-local composables in `composables/` are not. You must use explicit imports for those.
+
+## Styling
+
+Use **UnoCSS** classes (Tailwind Wind4 preset). Do not use Tailwind CSS directly.
+
+## i18n
+
+- UI strings go in `<i18n lang="yaml">` blocks inside Vue SFCs
+- Page content goes in `content/{en,zh}/` as Markdown files
+- Default locale is `zh` (Traditional Chinese); always provide both `zh` and `en`
+
+## Server API
+
+Nitro server routes live in `server/api/`. External API responses should be cached using `defineCachedFunction`. Shared request/response types go in `shared/types/` as Zod schemas.


### PR DESCRIPTION
## Summary

- Add `CONTRIBUTING.md` covering commit conventions, branch naming, dev scripts, code style, auto-imports, styling, i18n, and server API guidelines
- Move convention/workflow details out of `AGENTS.md` into `CONTRIBUTING.md` to avoid duplication — `AGENTS.md` now focuses on architecture
- Reference `CONTRIBUTING.md` from `AGENTS.md`

Will add zh-TW version if contents are OK.