### PR TITLE
fix: align past year links in footer

### DIFF
--- a/app/components/shared/CpFooter.vue
+++ b/app/components/shared/CpFooter.vue
@@ -121,18 +121,16 @@ const sitemaps = computed(() => tm('sitemap.items') as CommunityItem[])
       </div>
     </div>
 
-    <div class="mx-auto mt-12 pt-6 border-t border-gray-100 flex flex-wrap gap-1 max-w-[1100px]">
-      <div class="flex flex-wrap gap-1">
-        <NuxtLink
-          v-for="year in pastYears"
-          :key="year"
-          class="text-xs text-gray-400 px-2 py-1 rounded transition-colors hover:text-cp-green hover:bg-cp-green/6"
-          :href="`https://coscup.org/${year}/`"
-          target="_blank"
-        >
-          {{ year }}
-        </NuxtLink>
-      </div>
+    <div class="mx-auto mt-12 pt-6 border-t border-gray-100 flex flex-wrap gap-1 max-w-[1100px] tabular-nums">
+      <NuxtLink
+        v-for="year in pastYears"
+        :key="year"
+        class="text-xs text-gray-400 px-2 py-1 rounded transition-colors hover:text-cp-green hover:bg-cp-green/6"
+        :href="`https://coscup.org/${year}/`"
+        target="_blank"
+      >
+        {{ year }}
+      </NuxtLink>
     </div>
   </footer>
 </template>


### PR DESCRIPTION
Closes #120

## Summary

The past-year links in the footer (2006–2025) were not aligning into vertical columns when wrapped across rows because the proportional digit widths caused each link to take a slightly different width.

Adding `tabular-nums` (`font-variant-numeric: tabular-nums`) makes all digits share the same advance width, so each year link has identical width and the columns line up cleanly when wrapped. Also drops a redundant inner `flex flex-wrap gap-1` wrapper that duplicated the parent's layout.

## Test plan

- [x] Verified at narrow viewport (~700px) that years align in vertical columns when wrapped
- [x] `pnpm lint app/components/shared/CpFooter.vue` passes