### PR TITLE
feat(sheets): add cached API route and refactor data fetching

### DIFF
--- a/server/api/sheets/[sheet].get.ts
+++ b/server/api/sheets/[sheet].get.ts
@@ -1,0 +1,29 @@
+import { parse } from 'csv-parse/sync'
+import * as z from 'zod'
+import { SHEET_IDS, SHEET_NAMES } from '~~/shared/types/sheets'
+
+const requestSchema = z.object({
+  sheet: z.enum(SHEET_IDS),
+})
+
+export default defineCachedEventHandler(
+  async (event) => {
+    const { googleSheetId } = useRuntimeConfig()
+    if (!googleSheetId) {
+      throw createError('Missing NUXT_GOOGLE_SHEET_ID environment variable')
+    }
+
+    const { sheet } = await getValidatedRouterParams(event, requestSchema.parse)
+    const name = SHEET_NAMES[sheet]
+
+    const url = `https://docs.google.com/spreadsheets/d/${googleSheetId}/gviz/tq?tqx=out:csv&sheet=${encodeURIComponent(name)}`
+    const csv = await $fetch<string>(url, { responseType: 'text' })
+    const records = parse(csv, { columns: true, skip_empty_lines: true })
+    return records
+  },
+  {
+    maxAge: 31536000, // 1 year
+    staleMaxAge: 86400, // 1 day
+    swr: true,
+  },
+)

--- a/server/api/sheets/[sheet].get.ts
+++ b/server/api/sheets/[sheet].get.ts
@@ -1,6 +1,6 @@
 import { parse } from 'csv-parse/sync'
 import * as z from 'zod'
-import { SHEET_IDS, SHEET_NAMES } from '~~/shared/types/sheets'
+import { SHEET_IDS, SHEET_NAMES } from '#shared/types/sheets'
 
 const requestSchema = z.object({
   sheet: z.enum(SHEET_IDS),

--- a/server/api/sponsor.get.ts
+++ b/server/api/sponsor.get.ts
@@ -12,7 +12,7 @@ function transformImageUrl(source: string) {
 }
 
 export default defineEventHandler(async () => {
-  const sheets = await fetchSheet('sponsorList')
+  const sheets = await fetchSheet('sponsor-list')
 
   const sponsors = import.meta.dev
     ? sheets

--- a/server/api/sponsorship/add-ons.get.ts
+++ b/server/api/sponsorship/add-ons.get.ts
@@ -1,7 +1,7 @@
 export default defineEventHandler(async () => {
   const [addOnsZh, addOnsEn] = await Promise.all([
-    fetchSheet('sponsorshipAddOnsZh'),
-    fetchSheet('sponsorshipAddOnsEn'),
+    fetchSheet('sponsorship-add-ons-zh'),
+    fetchSheet('sponsorship-add-ons-en'),
   ])
 
   return addOnsZh.map((zh, index) => {

--- a/server/api/sponsorship/tiers.get.ts
+++ b/server/api/sponsorship/tiers.get.ts
@@ -1,5 +1,5 @@
 export default defineEventHandler(async () => {
-  const sheet = await fetchSheet('sponsorshipTiers')
+  const sheet = await fetchSheet('sponsorship-tiers')
 
   return sheet.map(({
     level,

--- a/server/utils/sheets/index.ts
+++ b/server/utils/sheets/index.ts
@@ -1,28 +1,14 @@
-import type { z } from 'zod'
-import { parse } from 'csv-parse/sync'
-import { SponsorListRowSchema } from '#shared/types/sponsor'
-import { SponsorshipAddOnSchema, SponsorshipTierSchema } from '#shared/types/sponsorship'
+import type { SheetID } from '~~/shared/types/sheets'
+import { z } from 'zod'
+import { SHEET_SCHEMAS } from '~~/shared/types/sheets'
 
-const SHEETS = {
-  sponsorshipTiers: { name: '贊助方案', schema: SponsorshipTierSchema },
-  sponsorshipAddOnsZh: { name: '贊助方案加價購（中文）', schema: SponsorshipAddOnSchema },
-  sponsorshipAddOnsEn: { name: '贊助方案加價購（英文）', schema: SponsorshipAddOnSchema },
-  sponsorList: { name: '贊助列表', schema: SponsorListRowSchema },
-}
+type SheetResult<K extends SheetID> = z.infer<(typeof SHEET_SCHEMAS)[K]>
 
-type SheetResult<K extends keyof typeof SHEETS> = z.infer<(typeof SHEETS)[K]['schema']>
-
-export async function fetchSheet<K extends keyof typeof SHEETS>(
-  sheetName: K,
+export async function fetchSheet<K extends SheetID>(
+  sheetID: K,
 ): Promise<SheetResult<K>[]> {
-  const { googleSheetId } = useRuntimeConfig()
-  if (!googleSheetId) {
-    throw createError('Missing NUXT_GOOGLE_SHEET_ID environment variable')
-  }
+  const records = await $fetch(`/api/sheets/${sheetID}`)
+  const recordsSchema = z.array(SHEET_SCHEMAS[sheetID])
 
-  const sheet = SHEETS[sheetName]
-  const url = `https://docs.google.com/spreadsheets/d/${googleSheetId}/gviz/tq?tqx=out:csv&sheet=${encodeURIComponent(sheet.name)}`
-  const csv = await $fetch<string>(url, { responseType: 'text' })
-  const records = parse(csv, { columns: true, skip_empty_lines: true })
-  return records.map((row) => sheet.schema.parse(row)) as SheetResult<K>[]
+  return recordsSchema.parse(records)
 }

--- a/server/utils/sheets/index.ts
+++ b/server/utils/sheets/index.ts
@@ -1,6 +1,6 @@
-import type { SheetID } from '~~/shared/types/sheets'
+import type { SheetID } from '#shared/types/sheets'
 import { z } from 'zod'
-import { SHEET_SCHEMAS } from '~~/shared/types/sheets'
+import { SHEET_SCHEMAS } from '#shared/types/sheets'
 
 type SheetResult<K extends SheetID> = z.infer<(typeof SHEET_SCHEMAS)[K]>
 

--- a/shared/types/sheets.ts
+++ b/shared/types/sheets.ts
@@ -1,0 +1,19 @@
+import type z from 'zod'
+import { SponsorListRowSchema } from './sponsor'
+import { SponsorshipAddOnSchema, SponsorshipTierSchema } from './sponsorship'
+
+export type SheetID = typeof SHEET_IDS[number]
+
+export const SHEET_IDS = Object.freeze(['sponsorship-tiers', 'sponsorship-add-ons-zh', 'sponsorship-add-ons-en', 'sponsor-list'] as const)
+export const SHEET_NAMES = Object.freeze({
+  'sponsorship-tiers': '贊助方案',
+  'sponsorship-add-ons-zh': '贊助方案加價購（中文）',
+  'sponsorship-add-ons-en': '贊助方案加價購（英文）',
+  'sponsor-list': '贊助列表',
+} satisfies Record<SheetID, string>)
+export const SHEET_SCHEMAS = Object.freeze({
+  'sponsorship-tiers': SponsorshipTierSchema,
+  'sponsorship-add-ons-zh': SponsorshipAddOnSchema,
+  'sponsorship-add-ons-en': SponsorshipAddOnSchema,
+  'sponsor-list': SponsorListRowSchema,
+} satisfies Record<SheetID, z.Schema>)

--- a/shared/types/sheets.ts
+++ b/shared/types/sheets.ts
@@ -1,4 +1,4 @@
-import type z from 'zod'
+import type * as z from 'zod'
 import { SponsorListRowSchema } from './sponsor'
 import { SponsorshipAddOnSchema, SponsorshipTierSchema } from './sponsorship'
 


### PR DESCRIPTION
## 動機

原本的 `fetchSheet` 沒有任何快取機制，每次請求都直接打 Google Sheets API。

這次的重構做了兩件事：

1. **在 API 源頭加入 SWR cache**：新增 `GET /api/sheets/[sheet]` route，以 `defineCachedEventHandler` 快取原始 CSV records（`maxAge: 1 year`、`staleMaxAge: 1 day`）。快取 key 只跟試算表資料有關，schema 改動不影響 cache hit。

2. **為 #87（無環境變數也能開專案）鋪路**：這些 route 現在是標準 Nitro API endpoint，可以在 `nuxt generate` 時 prerender 成靜態 JSON 檔案。之後在 #87 的情境下，可以把這類 API 的 `baseURL` 切換成 `coscup.org/2026`，讓本機開發者直接吃線上已 prerender 的資料，不需要自己設定 `NUXT_GOOGLE_SHEET_ID`。

## 變更摘要

- 新增 `server/api/sheets/[sheet].get.ts`：快取原始 Google Sheets CSV records（SWR）
- 新增 `shared/types/sheets.ts`：集中管理 sheet ID、名稱與對應 Zod schema 的映射
- 重構 `server/utils/sheets/index.ts`：改用 `$fetch('/api/sheets/...')` 取得資料，移除重複的 CSV 解析邏輯
- Sheet ID 改為 kebab-case（`sponsorList` → `sponsor-list` 等）

## Test plan

- [x] `pnpm dev` 確認贊助商列表、贊助方案頁面正常載入
- [x] 確認 `/api/sheets/sponsor-list` 等 route 回傳正確 JSON
- [x] `pnpm build` 確認靜態生成無誤

### 測試結果

**環境：** branch `add-cached-sheets-api`，本機 dev server（`pnpm dev`）

**API endpoints（`pnpm dev`）：**
- `GET /api/sheets/sponsorship-tiers` → 200，回傳 titanium/diamond/gold/silver/bronze/friend 等各方案資料 ✅
- `GET /api/sheets/sponsorship-add-ons-zh` → 200，回傳中文加價購項目（攤位、Main Track 等）✅
- `GET /api/sheets/sponsorship-add-ons-en` → 200，回傳英文加價購項目 ✅
- `GET /api/sheets/sponsor-list` → 200，回傳 `[]`（目前尚無贊助商資料，正常）✅
- `GET /api/sheets/invalid-sheet` → 400 Validation Error，Zod 正確拒絕無效 sheet ID ✅

**頁面載入：**
- `/2026/sponsor` → 200 ✅
- `/2026/sponsorship/` → 200 ✅

**靜態生成（`pnpm build`）：**
- 247 個 route 成功 prerender，無錯誤或警告 ✅

**Lint / Typecheck：**
- `pnpm lint` → 無錯誤 ✅
- `pnpm typecheck` → 無錯誤 ✅

Closes / contributes to #87