### PR TITLE
feat: use fs driver for nitro cache storage in production

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -18,6 +18,12 @@ export default defineNuxtConfig({
     output: {
       publicDir: process.env.NUXT_OUTPUT_DIR || '.output/public',
     },
+
+    storage: {
+      cache: {
+        driver: 'fs',
+      },
+    },
   },
 
   imports: {


### PR DESCRIPTION
## Summary

- Changes the default Nitro cache storage driver from `memory` to `fs` for production builds
- This persists the API cache (#123, #124) across server restarts/deploys instead of losing it on every cold start

## Test plan

- [x] Deploy to staging and verify cache files are written to `node_modules/.cache/nuxt/.nuxt/cache/nitro/handlers` on disk
- [x] `pnpm build` confirm cached API responses are served without hitting upstream