### PR TITLE
feat: fall back to NUXT_COSCUP_BASE_URL when API credentials are absent

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -67,6 +67,7 @@ export default defineNuxtConfig({
     pretalxApiToken: '',
     pretalxApiUrl: '',
     googleSheetId: '',
+    coscupBaseUrl: 'https://coscup.org/2026',
   },
 
   gtag: {

--- a/server/utils/pretalx/fetch.ts
+++ b/server/utils/pretalx/fetch.ts
@@ -1,6 +1,6 @@
 import type { PretalxData } from '#shared/types/pretalx'
 
-function pretalxFetchOptions(): { baseURL: string } | Record<never, never> {
+function pretalxFetchOptions(): { baseURL?: string } {
   const { pretalxApiToken, pretalxApiUrl, coscupBaseUrl } = useRuntimeConfig()
   if (pretalxApiToken && pretalxApiUrl) {
     return {}

--- a/server/utils/pretalx/fetch.ts
+++ b/server/utils/pretalx/fetch.ts
@@ -1,31 +1,45 @@
 import type { PretalxData } from '#shared/types/pretalx'
 
+function pretalxFetchOptions(): { baseURL: string } | Record<never, never> {
+  const { pretalxApiToken, pretalxApiUrl, coscupBaseUrl } = useRuntimeConfig()
+  if (pretalxApiToken && pretalxApiUrl) {
+    return {}
+  }
+  if (!coscupBaseUrl) {
+    throw createError({
+      statusCode: 500,
+      message: 'Missing NUXT_PRETALX_API_URL/NUXT_PRETALX_API_TOKEN and no NUXT_COSCUP_BASE_URL fallback configured',
+    })
+  }
+  return { baseURL: coscupBaseUrl }
+}
+
 export async function fetchSubmissions(): Promise<PretalxData<'submissions'>> {
-  const arr = await $fetch('/api/pretalx/submissions')
+  const arr = await $fetch('/api/pretalx/submissions', pretalxFetchOptions())
   return { arr, map: Object.fromEntries(arr.map((s) => [s.code, s])) }
 }
 
 export async function fetchSpeakers(): Promise<PretalxData<'speakers'>> {
-  const arr = await $fetch('/api/pretalx/speakers')
+  const arr = await $fetch('/api/pretalx/speakers', pretalxFetchOptions())
   return { arr, map: Object.fromEntries(arr.map((s) => [s.code, s])) }
 }
 
 export async function fetchSubmissionTypes(): Promise<PretalxData<'submission-types'>> {
-  const arr = await $fetch('/api/pretalx/submission-types')
+  const arr = await $fetch('/api/pretalx/submission-types', pretalxFetchOptions())
   return { arr, map: Object.fromEntries(arr.map((t) => [t.id, t])) }
 }
 
 export async function fetchRooms(): Promise<PretalxData<'rooms'>> {
-  const arr = await $fetch('/api/pretalx/rooms')
+  const arr = await $fetch('/api/pretalx/rooms', pretalxFetchOptions())
   return { arr, map: Object.fromEntries(arr.map((r) => [r.id, r])) }
 }
 
 export async function fetchAnswers(): Promise<PretalxData<'answers'>> {
-  const arr = await $fetch('/api/pretalx/answers')
+  const arr = await $fetch('/api/pretalx/answers', pretalxFetchOptions())
   return { arr, map: Object.fromEntries(arr.map((a) => [a.id, a])) }
 }
 
 export async function fetchSlots(): Promise<PretalxData<'slots'>> {
-  const arr = await $fetch('/api/pretalx/slots')
+  const arr = await $fetch('/api/pretalx/slots', pretalxFetchOptions())
   return { arr, map: Object.fromEntries(arr.map((s) => [s.id, s])) }
 }

--- a/server/utils/sheets/index.ts
+++ b/server/utils/sheets/index.ts
@@ -7,7 +7,19 @@ type SheetResult<K extends SheetID> = z.infer<(typeof SHEET_SCHEMAS)[K]>
 export async function fetchSheet<K extends SheetID>(
   sheetID: K,
 ): Promise<SheetResult<K>[]> {
-  const records = await $fetch(`/api/sheets/${sheetID}`)
+  const { googleSheetId, coscupBaseUrl } = useRuntimeConfig()
+  let baseURL: string | undefined
+  if (!googleSheetId) {
+    if (!coscupBaseUrl) {
+      throw createError({
+        statusCode: 500,
+        message: 'Missing NUXT_GOOGLE_SHEET_ID and no NUXT_COSCUP_BASE_URL fallback configured',
+      })
+    }
+    baseURL = coscupBaseUrl
+  }
+
+  const records = await $fetch(`/api/sheets/${sheetID}`, baseURL !== undefined ? { baseURL } : {})
   const recordsSchema = z.array(SHEET_SCHEMAS[sheetID])
 
   return recordsSchema.parse(records)


### PR DESCRIPTION
## Context

Stacked on #123.

When `NUXT_PRETALX_API_TOKEN`/`NUXT_PRETALX_API_URL` or `NUXT_GOOGLE_SHEET_ID` are absent, the server currently throws a 500. This PR adds a graceful fallback: fetch data from a pre-deployed instance instead, controlled by a new env var `NUXT_COSCUP_BASE_URL` (default: `https://coscup.org/2026`).

Goal: local dev and fork deployments work out-of-the-box without secrets.

## Changes

- **`nuxt.config.ts`** — add `coscupBaseUrl: 'https://coscup.org/2026'` to `runtimeConfig` (env: `NUXT_COSCUP_BASE_URL`)
- **`server/utils/pretalx/fetch.ts`** — `pretalxFetchOptions()` returns `{ baseURL: coscupBaseUrl }` when credentials are missing, or `{}` when they are present (empty options preserves Nitro's internal fetch behaviour)
- **`server/utils/sheets/index.ts`** — `fetchSheet` routes to `coscupBaseUrl` when `googleSheetId` is absent

`handler.ts` and `[sheet].get.ts` are unchanged; the fallback is handled at the fetch-utility layer.

## Test plan

Run the one-shot test script below. It spins up two dev servers — one with real credentials, one without — to verify both paths.

Requirements:
- `.env` with valid `NUXT_PRETALX_API_TOKEN`, `NUXT_PRETALX_API_URL`, `NUXT_GOOGLE_SHEET_ID`
- Ports 3333 and 3334 free

<details>

<summary>Integration Test</summary>

```js
// test-fallback.mjs  — run with: node test-fallback.mjs
import { execSync, spawn } from 'node:child_process'
import { mkdtempSync, rmSync } from 'node:fs'
import { tmpdir } from 'node:os'
import { join } from 'node:path'
import { setTimeout as sleep } from 'node:timers/promises'

const GREEN = '\x1B[32m', RED = '\x1B[31m', YELLOW = '\x1B[33m', RESET = '\x1B[0m'
let failed = false
const procs = []
let worktreePath = null
const API_BASE = '/2026'

const pass = (msg) => console.log(`${GREEN}✓${RESET} ${msg}`)
const fail = (msg) => { console.error(`${RED}✗${RESET} ${msg}`); failed = true }
const info = (msg) => console.log(`\n${YELLOW}▶${RESET} ${msg}`)

function cleanup() {
  for (const p of procs) try { p.kill('SIGTERM') } catch {}
  if (worktreePath) try { execSync(`git worktree remove --force "${worktreePath}"`, { stdio: 'ignore' }) } catch {}
}
process.on('exit', cleanup)
process.on('SIGINT', () => process.exit(130))

function startDev(cwd, port, extraEnv = {}) {
  return new Promise((resolve, reject) => {
    const proc = spawn('pnpm', ['dev'], {
      cwd, env: { ...process.env, NITRO_PORT: String(port), ...extraEnv }, stdio: ['ignore', 'pipe', 'pipe'],
    })
    procs.push(proc)
    const onData = (data) => {
      const str = data.toString()
      if (/Local:|ready in|Listening/i.test(str)) { process.stdout.write(`  [:${port}] ${str.trim()}\n`); resolve(proc) }
    }
    proc.stdout.on('data', onData); proc.stderr.on('data', onData); proc.on('error', reject)
    setTimeout(() => reject(new Error(`Port ${port}: server didn't start within 2 min`)), 120_000)
  })
}

async function waitHTTP(port, maxRetries = 40) {
  for (let i = 0; i < maxRetries; i++) {
    try {
      const r = await fetch(`http://localhost:${port}${API_BASE}/`, { signal: AbortSignal.timeout(3000), redirect: 'manual' })
      if (r.status < 500) return
    } catch {}
    await sleep(2000)
  }
  throw new Error(`Port ${port}: HTTP health check timed out`)
}

async function check(port, path, label) {
  try {
    const res = await fetch(`http://localhost:${port}${API_BASE}${path}`, { signal: AbortSignal.timeout(120_000) })
    if (!res.ok) { fail(`${label}: HTTP ${res.status} — ${(await res.text()).slice(0, 120)}`); return }
    const data = await res.json()
    const count = Array.isArray(data) ? data.length : (data && typeof data === 'object' ? Object.keys(data).length : -1)
    count > 0 ? pass(`${label}: ${count} item(s)`) : count === 0 ? fail(`${label}: empty`) : fail(`${label}: unexpected shape`)
  } catch (err) { fail(`${label}: ${err.message}`) }
}

info('Starting server WITH credentials on port 3333...')
await startDev(process.cwd(), 3333)
await waitHTTP(3333); await sleep(1000)

console.log('\n── Test 1: Direct credentials ──')
await check(3333, '/api/session', 'Pretalx → /api/session')
await check(3333, '/api/sponsorship/tiers', 'Sheets  → /api/sponsorship/tiers')

info('Creating temp worktree for fallback test...')
worktreePath = mkdtempSync(join(tmpdir(), 'coscup-fallback-'))
rmSync(worktreePath, { recursive: true })
execSync(`git worktree add "${worktreePath}" HEAD`, { cwd: process.cwd(), stdio: 'ignore' })
execSync(`ln -s "${process.cwd()}/node_modules" "${worktreePath}/node_modules"`)
for (const f of ['nuxt.config.ts', 'server/utils/pretalx/fetch.ts', 'server/utils/sheets/index.ts'])
  execSync(`cp "${process.cwd()}/${f}" "${worktreePath}/${f}"`)

info('Starting server WITHOUT credentials (fallback → :3333/2026) on port 3334...')
await startDev(worktreePath, 3334, {
  NUXT_PRETALX_API_TOKEN: '', NUXT_PRETALX_API_URL: '', NUXT_GOOGLE_SHEET_ID: '',
  NUXT_COSCUP_BASE_URL: 'http://localhost:3333/2026',
})
await waitHTTP(3334); await sleep(1000)

console.log('\n── Test 2: Fallback via NUXT_COSCUP_BASE_URL ──')
await check(3334, '/api/session', 'Fallback → /api/session')
await check(3334, '/api/sponsorship/tiers', 'Fallback → /api/sponsorship/tiers')

if (failed) {
  console.error(`\n${RED}❌ Some tests failed${RESET}`)
  process.exit(1)
} else {
  console.log(`\n${GREEN}✅ All tests passed${RESET}`)
  process.exit(0)
}
```

</details>