### PR TITLE
fix: render sponsor intro content correctly in cards

### DIFF
--- a/app/components/feature/CpSponsorCard.vue
+++ b/app/components/feature/CpSponsorCard.vue
@@ -46,9 +46,10 @@ const needsExpand = computed(() => sponsor.intro[locale.value]?.length > 200)
           class="peer sr-only"
           type="checkbox"
         >
-        <p class="text-sm text-primary-700 leading-7 mt-3 text-left line-clamp-5 peer-checked:line-clamp-none">
-          <MDC :value="sponsor.intro[locale]" />
-        </p>
+        <MDC
+          class="text-sm text-primary-700 leading-7 mt-3 text-left line-clamp-5 peer-checked:line-clamp-none"
+          :value="sponsor.intro[locale]"
+        />
         <label
           class="text-xs text-primary-500 mt-1 block cursor-pointer hover:underline peer-checked:hidden"
           :for="`expand-${sponsor.id}`"
@@ -63,12 +64,11 @@ const needsExpand = computed(() => sponsor.intro[locale.value]?.length > 200)
         </label>
       </template>
 
-      <p
+      <MDC
         v-else
         class="text-sm text-primary-700 leading-7 mt-3 text-left"
-      >
-        <MDC :value="sponsor.intro[locale]" />
-      </p>
+        :value="sponsor.intro[locale]"
+      />
     </div>
   </article>
 </template>


### PR DESCRIPTION
## Summary

這次修改修正了 sponsor 卡片中 `intro` 內容未正常顯示的問題。原因是 `CpSponsorCard.vue` 原本把 `MDC` 包在 `<p>` 內，而 `MDC` 預設會輸出 `div`，造成無效的 HTML 結構，瀏覽器自動重排後讓內容看起來像沒有渲染。

## Changes

- 調整 app/components/feature/CpSponsorCard.vue 的 `intro` 渲染方式，移除外層 `<p>` 包裝。
- 在 `needsExpand` 分支中，改為直接將樣式 class 掛在 `<MDC>` 上，避免產生 `<p><div></div></p>` 的無效結構。
- 在 `v-else` 分支中，也改為直接渲染 `<MDC>`，並保留原本的文字樣式與 spacing。