### PR TITLE
feat: enrich event JSON-LD with details and subEvent

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -2,8 +2,35 @@ import { defineNuxtConfig } from 'nuxt/config'
 
 const YEAR = '2026'
 const TITLE = 'COSCUP 2026 x UbuCon Asia'
+const TITLE_ZH = '開源人年會 2026 x UbuCon Asia'
 const DESC = 'Conference for Open Source Coders, Users, and Promoters is a free annual conference providing a platform to connect FLOSS folks across Asia since 2006. It\'s a major force of free software movement advocacy in Taiwan.'
 const URL = `https://coscup.org/${YEAR}/`
+
+const EVENT_COMMON = {
+  startDate: '2026-08-08T09:00:00+08:00',
+  endDate: '2026-08-09T17:00:00+08:00',
+  eventStatus: 'https://schema.org/EventScheduled',
+  eventAttendanceMode: 'https://schema.org/OfflineEventAttendanceMode',
+  inLanguage: ['zh-Hant-TW', 'en'],
+  location: {
+    '@type': 'Place',
+    'name': 'National Taiwan University of Science and Technology',
+    'sameAs': 'https://en.wikipedia.org/wiki/National_Taiwan_University_of_Science_and_Technology',
+    'address': {
+      '@type': 'PostalAddress',
+      'streetAddress': 'No. 43, Sec. 4, Keelung Road',
+      'addressLocality': 'Da\'an District',
+      'addressRegion': 'Taipei',
+      'postalCode': '106335',
+      'addressCountry': 'TW',
+    },
+    'geo': {
+      '@type': 'GeoCoordinates',
+      'latitude': 25.0137,
+      'longitude': 121.5405,
+    },
+  },
+}
 
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
@@ -37,19 +64,26 @@ export default defineNuxtConfig({
             '@context': 'https://schema.org',
             '@type': 'Event',
             'name': TITLE,
-            'startDate': '2026-08-08',
-            'endDate': '2026-08-09',
-            'eventStatus': 'https://schema.org/EventScheduled',
-            'eventAttendanceMode': 'https://schema.org/OfflineEventAttendanceMode',
-            'location': {
-              '@type': 'Place',
-              'name': 'Taiwan',
-            },
+            'alternateName': TITLE_ZH,
             'description': DESC,
+            'url': URL,
+            ...EVENT_COMMON,
+            'isAccessibleForFree': true,
+            'image': [`${URL}coscup_logo.png`],
             'organizer': {
               '@type': 'Organization',
               'name': 'COSCUP',
-              'url': 'https://coscup.org',
+              'url': 'https://coscup.org/',
+              'sameAs': [
+                'https://en.wikipedia.org/wiki/COSCUP',
+                'https://www.wikidata.org/wiki/Q10846717',
+              ],
+            },
+            'subEvent': {
+              '@type': 'Event',
+              'name': 'UbuCon Asia 2026',
+              'url': 'https://2026.ubucon.asia/',
+              ...EVENT_COMMON,
             },
           }),
         },


### PR DESCRIPTION
研究完 JSON-LD 格式後，對 #128 的後續修改。
為 `nuxt.config.ts` 裡的 JSON-LD 資料增加更多年會的詳細資訊：

- 含時區的 ISO 時間：Google 建議加上為時間資訊加上有時區的時間。單獨日期可能會在其他時區顯示錯誤的日期。
- [`isAccessibleForFree: true`](https://schema.org/isAccessibleForFree)：標記這是一個免費活動。跳過了 `Offer` 區塊，因為 COSCUP 不需要票。
- `PostalAddress` 地址和 `geo` 坐標：改善地圖顯示。
- [`alternateName`](https://schema.org/alternateName)：用來標注活動的別名，這裡用來標示中文原名。在做出完整 i18n SEO 前的臨時方案。
- `sameAs` 標注 Wikidata：為 Google 資訊卡提供資料。
- `subEvent` 標注 UbuCon Asia：用原生的方式標示合辦活動。
- `image`：暫時用專案已經有的 `coscup_logo.png`，之後應用 16:9 / 1200×630 OG image 替換。

[Google 檢查工具結果](https://search.google.com/test/rich-results/result?id=lnf0tnlsvJcGzIP8TqIjEA)

<details>
<summary>計算後的完整 JSON-LD</summary>

```json
{
  "@context": "https://schema.org",
  "@type": "Event",
  "name": "COSCUP 2026 x UbuCon Asia",
  "alternateName": "開源人年會 2026 x UbuCon Asia",
  "description": "Conference for Open Source Coders, Users, and Promoters is a free annual conference providing a platform to connect FLOSS folks across Asia since 2006. It's a major force of free software movement advocacy in Taiwan.",
  "url": "https://coscup.org/2026/",
  "startDate": "2026-08-08T09:00:00+08:00",
  "endDate": "2026-08-09T17:00:00+08:00",
  "eventStatus": "https://schema.org/EventScheduled",
  "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
  "inLanguage": ["zh-Hant-TW", "en"],
  "location": {
    "@type": "Place",
    "name": "National Taiwan University of Science and Technology",
    "sameAs": "https://en.wikipedia.org/wiki/National_Taiwan_University_of_Science_and_Technology",
    "address": {
      "@type": "PostalAddress",
      "streetAddress": "No. 43, Sec. 4, Keelung Road",
      "addressLocality": "Da'an District",
      "addressRegion": "Taipei",
      "postalCode": "106335",
      "addressCountry": "TW"
    },
    "geo": {
      "@type": "GeoCoordinates",
      "latitude": 25.0137,
      "longitude": 121.5405
    }
  },
  "isAccessibleForFree": true,
  "image": [
    "https://coscup.org/2026/coscup_logo.png"
  ],
  "organizer": {
    "@type": "Organization",
    "name": "COSCUP",
    "url": "https://coscup.org/",
    "sameAs": [
      "https://en.wikipedia.org/wiki/COSCUP",
      "https://www.wikidata.org/wiki/Q10846717"
    ]
  },
  "subEvent": {
    "@type": "Event",
    "name": "UbuCon Asia 2026",
    "url": "https://2026.ubucon.asia/",
    "startDate": "2026-08-08T09:00:00+08:00",
    "endDate": "2026-08-09T17:00:00+08:00",
    "eventStatus": "https://schema.org/EventScheduled",
    "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
    "inLanguage": ["zh-Hant-TW", "en"],
    "location": {
      "@type": "Place",
      "name": "National Taiwan University of Science and Technology",
      "sameAs": "https://en.wikipedia.org/wiki/National_Taiwan_University_of_Science_and_Technology",
      "address": {
        "@type": "PostalAddress",
        "streetAddress": "No. 43, Sec. 4, Keelung Road",
        "addressLocality": "Da'an District",
        "addressRegion": "Taipei",
        "postalCode": "106335",
        "addressCountry": "TW"
      },
      "geo": {
        "@type": "GeoCoordinates",
        "latitude": 25.0137,
        "longitude": 121.5405
      }
    }
  }
}
```

</details>