### PR TITLE
fix: exclude Leaflet map from prose styles to correct overlay alignment

### DIFF
--- a/app/components/content/LeafletMap.vue
+++ b/app/components/content/LeafletMap.vue
@@ -32,7 +32,7 @@ onMounted(async () => {
 <template>
   <div
     ref="mapEl"
-    class="h-100"
+    class="not-prose h-100"
   />
 </template>
 


### PR DESCRIPTION
fix #139

## Summary

這次修改修正了 `LeafletMap` 元件嵌入 markdown 內容頁時的地圖偏移問題。原因是地圖容器受到 `.prose` typography 樣式影響，導致 Leaflet 疊圖與底圖對齊異常。

## Changes

- 在 `app/components/content/LeafletMap.vue` 的地圖容器加入 `not-prose` 樣式，讓 Leaflet 地圖區塊不再套用 markdown typography 樣式