### PR TITLE
Perf/session UI

### DIFF
--- a/app/components/feature/CpSessionDaySelector.vue
+++ b/app/components/feature/CpSessionDaySelector.vue
@@ -17,7 +17,7 @@ const activeDay = computed(() => selectedDay.value ?? props.days[0] ?? '')
 </script>
 
 <template>
-  <div class="px-6 pb-4 pt-3 border-b border-primary-100 flex justify-center">
+  <div class="px-6 pb-4 pt-3 flex justify-center">
     <div class="flex flex-wrap gap-3 items-center justify-center">
       <button
         v-for="day in days"

--- a/app/components/feature/CpSessionList.vue
+++ b/app/components/feature/CpSessionList.vue
@@ -30,7 +30,7 @@ const times = Object.keys(sessions.value).sort()
 </script>
 
 <template>
-  <div class="flex flex-col gap-6">
+  <div class="flex flex-col gap-6 w-screen">
     <section
       v-for="time in times"
       :key="time"

--- a/app/components/feature/CpSessionTable.vue
+++ b/app/components/feature/CpSessionTable.vue
@@ -15,7 +15,7 @@ const { sessions: _sessions, day, timeRange, interval, rowHeight, columnWidth } 
 
 const { locale } = useI18n()
 
-const { containerRef, isDragging } = useDragScroll({ vertical: false })
+const { containerRef, isDragging } = useDragScroll({ scrollTarget: 'window' })
 
 function parseMinutes(isoStr: string) {
   const match = isoStr.match(/T(\d{2}):(\d{2})/)

--- a/app/components/feature/CpSessionTable.vue
+++ b/app/components/feature/CpSessionTable.vue
@@ -2,6 +2,7 @@
 import type { SessionSummary } from '#shared/types/session'
 import { useI18n } from '#imports'
 import { useDragScroll } from '~/composables/useDragScroll'
+import { useRealtime } from '~/composables/useRealtime'
 import CpSessionItem from './CpSessionItem.vue'
 
 const { sessions: _sessions, day, timeRange, interval, rowHeight, columnWidth } = defineProps<{
@@ -14,6 +15,7 @@ const { sessions: _sessions, day, timeRange, interval, rowHeight, columnWidth } 
 }>()
 
 const { locale } = useI18n()
+const { time } = useRealtime()
 
 const { containerRef, isDragging } = useDragScroll({ scrollTarget: 'window' })
 
@@ -92,12 +94,17 @@ const sessions = computed(() => {
       }
     })
 })
+
+const nowLineTop = computed(() => {
+  const sec = time.value.getHours() * 60 + time.value.getMinutes() + time.value.getSeconds() / 60
+  return rowHeight + ((sec - timeStart.value) / interval) * rowHeight
+})
 </script>
 
 <template>
   <div
     ref="containerRef"
-    class="border border-gray-200 rounded-xl grid overflow-clip"
+    class="border border-gray-200 rounded-xl grid relative overflow-clip"
     :class="isDragging ? 'cursor-grabbing select-none' : 'cursor-grab'"
     :style="{
       gridTemplateColumns: `4.5rem repeat(${rooms.length}, ${columnWidth}px)`,
@@ -115,7 +122,7 @@ const sessions = computed(() => {
     <div
       v-for="(room, i) in rooms"
       :key="room"
-      class="text-sm text-primary-400 font-medium border-b border-gray-200 bg-gray-50 flex items-center top-0 justify-center sticky z-10"
+      class="text-sm text-primary-400 font-medium border-b border-gray-200 bg-gray-50 flex items-center top-0 justify-center sticky z-20"
       :style="{
         'grid-row': 1,
         'grid-column': i + 2,
@@ -169,5 +176,12 @@ const sessions = computed(() => {
         :title="session.title"
       />
     </NuxtLink>
+
+    <ClientOnly>
+      <div
+        class="border-t-1 border-red-500 w-full pointer-events-none left-0 absolute z-10"
+        :style="{ top: `${nowLineTop}px` }"
+      />
+    </ClientOnly>
   </div>
 </template>

--- a/app/components/feature/CpSessionTable.vue
+++ b/app/components/feature/CpSessionTable.vue
@@ -96,8 +96,25 @@ const sessions = computed(() => {
 })
 
 const nowLineTop = computed(() => {
-  const sec = time.value.getHours() * 60 + time.value.getMinutes() + time.value.getSeconds() / 60
-  return rowHeight + ((sec - timeStart.value) / interval) * rowHeight
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'Asia/Taipei',
+    hour: 'numeric',
+    minute: 'numeric',
+    second: 'numeric',
+    hour12: false,
+  })
+  const parts = formatter.formatToParts(time.value)
+  const h = Number(parts.find((p) => p.type === 'hour')!.value)
+  const m = Number(parts.find((p) => p.type === 'minute')!.value)
+  const s = Number(parts.find((p) => p.type === 'second')!.value)
+  const mins = h * 60 + m + s / 60
+  return rowHeight + ((mins - timeStart.value) / interval) * rowHeight
+})
+
+const showRealtimeLine = computed(() => {
+  const iso = time.value.toISOString()
+  const todayStr = iso.slice(0, 10)
+  return day === todayStr && timeStart.value <= parseMinutes(iso) && parseMinutes(iso) <= timeEnd.value
 })
 </script>
 
@@ -179,6 +196,7 @@ const nowLineTop = computed(() => {
 
     <ClientOnly>
       <div
+        v-if="showRealtimeLine"
         class="border-t-1 border-red-500 w-full pointer-events-none left-0 absolute z-10"
         :style="{ top: `${nowLineTop}px` }"
       />

--- a/app/components/feature/CpSessionTable.vue
+++ b/app/components/feature/CpSessionTable.vue
@@ -4,12 +4,13 @@ import { useI18n } from '#imports'
 import { useDragScroll } from '~/composables/useDragScroll'
 import CpSessionItem from './CpSessionItem.vue'
 
-const { sessions: _sessions, day, timeRange, interval, rowHeight } = defineProps<{
+const { sessions: _sessions, day, timeRange, interval, rowHeight, columnWidth } = defineProps<{
   day: string
   timeRange: [string, string]
   sessions: SessionSummary[]
   interval: number
   rowHeight: number
+  columnWidth: number
 }>()
 
 const { locale } = useI18n()
@@ -99,7 +100,7 @@ const sessions = computed(() => {
     class="border border-gray-200 rounded-xl grid overflow-x-auto"
     :class="isDragging ? 'cursor-grabbing select-none' : 'cursor-grab'"
     :style="{
-      gridTemplateColumns: `4.5rem repeat(${rooms.length}, minmax(11rem, 1fr))`,
+      gridTemplateColumns: `4.5rem repeat(${rooms.length}, ${columnWidth}px)`,
       gridTemplateRows: `3rem repeat(${totalGridRows}, ${rowHeight}px)`,
     }"
   >

--- a/app/components/feature/CpSessionTable.vue
+++ b/app/components/feature/CpSessionTable.vue
@@ -97,7 +97,7 @@ const sessions = computed(() => {
 <template>
   <div
     ref="containerRef"
-    class="border border-gray-200 rounded-xl grid overflow-x-auto"
+    class="border border-gray-200 rounded-xl grid overflow-clip"
     :class="isDragging ? 'cursor-grabbing select-none' : 'cursor-grab'"
     :style="{
       gridTemplateColumns: `4.5rem repeat(${rooms.length}, ${columnWidth}px)`,
@@ -115,7 +115,7 @@ const sessions = computed(() => {
     <div
       v-for="(room, i) in rooms"
       :key="room"
-      class="text-sm text-primary-400 font-medium border-b border-gray-200 bg-gray-50 flex items-center justify-center"
+      class="text-sm text-primary-400 font-medium border-b border-gray-200 bg-gray-50 flex items-center top-0 justify-center sticky z-10"
       :style="{
         'grid-row': 1,
         'grid-column': i + 2,
@@ -129,7 +129,7 @@ const sessions = computed(() => {
       :key="label.label"
     >
       <div
-        class="text-xs text-gray-400 pr-2 pt-0.5 text-right border-t border-gray-100 bg-gray-50 flex items-start justify-center"
+        class="text-xs text-gray-400 pr-2 pt-0.5 text-right border-t border-gray-100 bg-gray-50 flex items-start left-0 justify-center sticky z-10"
         :style="{
           'grid-row': `${label.row} / ${label.row + 30 / interval}`,
           'grid-column': 1,

--- a/app/composables/useDragScroll.ts
+++ b/app/composables/useDragScroll.ts
@@ -1,9 +1,10 @@
 interface UseDragScrollOptions {
   horizontal?: boolean
   vertical?: boolean
+  scrollTarget?: 'container' | 'window'
 }
 
-export function useDragScroll({ horizontal = true, vertical = true }: UseDragScrollOptions = {}) {
+export function useDragScroll({ horizontal = true, vertical = true, scrollTarget = 'container' }: UseDragScrollOptions = {}) {
   const containerRef = ref<HTMLElement>()
   const isDragging = ref(false)
   const suppressClick = ref(false)
@@ -24,8 +25,15 @@ export function useDragScroll({ horizontal = true, vertical = true }: UseDragScr
     dragState.pointerId = event.pointerId
     dragState.startX = event.clientX
     dragState.startY = event.clientY
-    dragState.scrollLeft = containerRef.value.scrollLeft
-    dragState.scrollTop = containerRef.value.scrollTop
+
+    if (scrollTarget === 'window') {
+      dragState.scrollLeft = window.scrollX
+      dragState.scrollTop = window.scrollY
+    } else {
+      dragState.scrollLeft = containerRef.value.scrollLeft
+      dragState.scrollTop = containerRef.value.scrollTop
+    }
+
     isDragging.value = true
     suppressClick.value = false
 
@@ -49,11 +57,18 @@ export function useDragScroll({ horizontal = true, vertical = true }: UseDragScr
       suppressClick.value = true
     }
 
-    if (horizontal) {
-      containerRef.value.scrollLeft = dragState.scrollLeft - deltaX
-    }
-    if (vertical) {
-      containerRef.value.scrollTop = dragState.scrollTop - deltaY
+    if (scrollTarget === 'window') {
+      window.scrollTo({
+        left: horizontal ? dragState.scrollLeft - deltaX : window.scrollX,
+        top: vertical ? dragState.scrollTop - deltaY : window.scrollY,
+      })
+    } else {
+      if (horizontal) {
+        containerRef.value.scrollLeft = dragState.scrollLeft - deltaX
+      }
+      if (vertical) {
+        containerRef.value.scrollTop = dragState.scrollTop - deltaY
+      }
     }
   }
 

--- a/app/composables/useRealtime.ts
+++ b/app/composables/useRealtime.ts
@@ -1,0 +1,39 @@
+import { useRoute } from 'vue-router'
+
+export function useRealtime() {
+  const route = useRoute()
+
+  let interval: ReturnType<typeof setInterval> | null = null
+
+  const time = ref(new Date())
+
+  onMounted(() => {
+    const isTest = !!route.query.test
+
+    if (isTest) {
+      const testDate = route.query.test as string
+
+      if (!Number.isNaN(Date.parse(testDate))) {
+        time.value = new Date(testDate)
+      } else {
+        time.value = new Date('2026-08-09T09:00:00')
+      }
+    }
+
+    interval = isTest
+      ? setInterval(() => {
+          time.value = new Date(time.value.getTime() + 10_000)
+        }, 200)
+      : setInterval(() => {
+          time.value = new Date()
+        }, 1000)
+  })
+
+  onBeforeUnmount(() => {
+    if (interval) {
+      clearInterval(interval)
+    }
+  })
+
+  return { time }
+}

--- a/app/layouts/session-table.vue
+++ b/app/layouts/session-table.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+import CpFooter from '~/components/shared/CpFooter.vue'
+import CpNavbar from '~/components/shared/CpNavbar.vue'
+</script>
+
+<template>
+  <div class="w-max">
+    <CpNavbar class="w-screen left-0 sticky z-10" />
+    <main class="w-max">
+      <slot />
+    </main>
+
+    <CpFooter class="w-screen left-0 sticky" />
+  </div>
+</template>

--- a/app/layouts/session-table.vue
+++ b/app/layouts/session-table.vue
@@ -1,15 +1,29 @@
 <script setup lang="ts">
 import CpFooter from '~/components/shared/CpFooter.vue'
 import CpNavbar from '~/components/shared/CpNavbar.vue'
+
+function updateViewportWidth() {
+  document.documentElement.style.setProperty('--viewport-width', `${document.documentElement.clientWidth}px`)
+}
+
+onMounted(() => {
+  updateViewportWidth()
+  window.addEventListener('resize', updateViewportWidth)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('resize', updateViewportWidth)
+  document.documentElement.style.removeProperty('--viewport-width')
+})
 </script>
 
 <template>
   <div class="w-max">
-    <CpNavbar class="w-screen-noscroll left-0 sticky z-10" />
+    <CpNavbar class="w-[var(--viewport-width,100vw)] left-0 sticky z-10" />
     <main class="w-max">
       <slot />
     </main>
 
-    <CpFooter class="w-screen-noscroll left-0 sticky" />
+    <CpFooter class="w-[var(--viewport-width,100vw)] left-0 sticky" />
   </div>
 </template>

--- a/app/layouts/session-table.vue
+++ b/app/layouts/session-table.vue
@@ -5,11 +5,11 @@ import CpNavbar from '~/components/shared/CpNavbar.vue'
 
 <template>
   <div class="w-max">
-    <CpNavbar class="w-screen left-0 sticky z-10" />
+    <CpNavbar class="w-screen-noscroll left-0 sticky z-10" />
     <main class="w-max">
       <slot />
     </main>
 
-    <CpFooter class="w-screen left-0 sticky" />
+    <CpFooter class="w-screen-noscroll left-0 sticky" />
   </div>
 </template>

--- a/app/pages/session.vue
+++ b/app/pages/session.vue
@@ -22,6 +22,10 @@ prerenderRoutes(
     .flat()
     .map((s) => `/session/${s.id}`),
 )
+
+definePageMeta({
+  layout: 'session-table',
+})
 </script>
 
 <template>
@@ -31,7 +35,7 @@ prerenderRoutes(
     <div class="flex flex-col-reverse sm:flex-col">
       <CpSessionDaySelector
         v-model="selectedDay"
-        class="bottom-0 sticky z-10 sm:bottom-auto"
+        class="w-screen bottom-0 left-0 sticky z-10 sm:bottom-auto"
         :days="days"
       />
 
@@ -41,6 +45,7 @@ prerenderRoutes(
       />
       <CpSessionTable
         class="hidden sm:grid"
+        :column-width="200"
         :day="selectedDay"
         :interval="5"
         :row-height="50"

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -7,7 +7,9 @@ import presetThemes from 'unocss-preset-theme'
 
 export default defineConfig({
   shortcuts: {
-    icon: '-align-0.125em',
+    'icon': '-align-0.125em',
+    'w-screen-noscroll': 'w-[calc(100vw-12px)]',
+
   },
   extractors: [
     extractorMdc(),

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -7,9 +7,7 @@ import presetThemes from 'unocss-preset-theme'
 
 export default defineConfig({
   shortcuts: {
-    'icon': '-align-0.125em',
-    'w-screen-noscroll': 'sm:w-[calc(100vw-12px)] w-screen',
-
+    icon: '-align-0.125em',
   },
   extractors: [
     extractorMdc(),

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -8,7 +8,7 @@ import presetThemes from 'unocss-preset-theme'
 export default defineConfig({
   shortcuts: {
     'icon': '-align-0.125em',
-    'w-screen-noscroll': 'w-[calc(100vw-12px)]',
+    'w-screen-noscroll': 'sm:w-[calc(100vw-12px)] w-screen',
 
   },
   extractors: [


### PR DESCRIPTION
(AI 生成的)
## Summary

建立議程頁面的完整 UI，包含議程表格（桌面）、議程列表（手機）、議程詳細資訊彈窗，以及相關的互動與佈局改善。

### 新增功能
- **議程表格 (`CpSessionTable`)** — 桌面版以 CSS Grid 呈現時間軸議程表，支援拖曳捲動（window-level）、sticky 時間 / 房間標題、即時紅線指示目前時間
- **議程列表 (`CpSessionList`)** — 手機版依時間分群的議程列表，sticky 時間標題
- **議程詳細頁 (`session/[id].vue`)** — 右側滑入彈窗顯示議程摘要、講者資訊、共筆連結，ESC 可關閉
- **`CpSessionInfoCard`** — 議程詳細資訊卡片元件，支援 MDC 渲染 description 與 speaker bio
- **`useRealtime` composable** — 每秒更新的響應式時間，用於即時紅線
- **`session-table` layout** — 專用佈局，navbar/footer 使用 `--viewport-width` CSS 變數動態計算寬度，避免捲軸寬度問題
- **`router.options.ts`** — 自定義 scroll behavior，議程頁面間導航不重置捲動位置

### 改善
- **`useDragScroll`** — 新增 `scrollTarget: 'window'` 選項，支援 window-level 拖曳捲動
- **Viewport 寬度處理** — 移除硬編碼 `calc(100vw - 12px)` 的 `w-screen-noscroll` shortcut，改用 JS 動態量測 `document.documentElement.clientWidth` 設定 CSS 變數，相容不同 OS/瀏覽器的捲軸寬度
- **時區修正** — 即時紅線使用 `Intl.DateTimeFormat` 以 `Asia/Taipei` 時區計算目前時間，與 Pretalx 議程時間一致
- **Sticky headers** — 議程表格的房間標題列與時間標籤在捲動時保持可見
- **Day selector** — 移除底部 border，手機版改為 sticky 在畫面底部
- **Session 頁面路由 prerender** — 透過 `prerenderRoutes` 預渲染所有議程詳細頁
