### PR TITLE
feat(pretalx): return difficulty, track, and tags on sessions (#171)

### DIFF
--- a/server/api/session/[id]/index.get.ts
+++ b/server/api/session/[id]/index.get.ts
@@ -1,5 +1,5 @@
 import pretalxData from '#server/utils/pretalx'
-import { parseAnswer, parseSlot, parseSpeaker, parseType } from '#server/utils/pretalx/parser'
+import { parseAnswer, parseDifficulty, parseSlot, parseSpeaker, parseTags, parseTrack, parseType } from '#server/utils/pretalx/parser'
 
 export default defineEventHandler(async (event) => {
   const id = getRouterParam(event, 'id')!
@@ -39,6 +39,8 @@ export default defineEventHandler(async (event) => {
     start: slot?.start,
     end: slot?.end,
     language: answers.language,
+    difficulty: parseDifficulty(answers.difficulty),
+    track: parseTrack(submission.track, data),
     speakers,
     zh: {
       title: submission.title,
@@ -50,7 +52,7 @@ export default defineEventHandler(async (event) => {
       describe: answers.enDesc || submission.abstract,
       type: type.name.en || type.name['zh-hans'],
     },
-    tags: [],
+    tags: parseTags(submission.tags, data),
     uri: `https://coscup.org/2026/session/${submission.code}`,
     co_write: null,
     qa: null,

--- a/server/api/session/[id]/index.get.ts
+++ b/server/api/session/[id]/index.get.ts
@@ -1,5 +1,5 @@
 import pretalxData from '#server/utils/pretalx'
-import { parseAnswer, parseSlot, parseSpeaker, parseTags, parseTrack, parseType } from '#server/utils/pretalx/parser'
+import { parseAnswer, parseDifficulty, parseSlot, parseSpeaker, parseTags, parseTrack, parseType } from '#server/utils/pretalx/parser'
 
 export default defineEventHandler(async (event) => {
   const id = getRouterParam(event, 'id')!

--- a/server/api/session/[id]/index.get.ts
+++ b/server/api/session/[id]/index.get.ts
@@ -1,5 +1,5 @@
 import pretalxData from '#server/utils/pretalx'
-import { parseAnswer, parseDifficulty, parseSlot, parseSpeaker, parseTags, parseTrack, parseType } from '#server/utils/pretalx/parser'
+import { parseAnswer, parseSlot, parseSpeaker, parseTags, parseTrack, parseType } from '#server/utils/pretalx/parser'
 
 export default defineEventHandler(async (event) => {
   const id = getRouterParam(event, 'id')!
@@ -39,7 +39,6 @@ export default defineEventHandler(async (event) => {
     start: slot?.start,
     end: slot?.end,
     language: answers.language,
-    difficulty: parseDifficulty(answers.difficulty),
     track: parseTrack(submission.track, data),
     speakers,
     zh: {
@@ -52,7 +51,7 @@ export default defineEventHandler(async (event) => {
       describe: answers.enDesc || submission.abstract,
       type: type.name.en || type.name['zh-hans'],
     },
-    tags: parseTags(submission.tags, data),
+    tags: parseTags(submission.tags, data, parseDifficulty(answers.difficulty)),
     uri: `https://coscup.org/2026/session/${submission.code}`,
     co_write: null,
     qa: null,

--- a/server/api/session/index.get.ts
+++ b/server/api/session/index.get.ts
@@ -1,7 +1,7 @@
 import type { Submission } from '#shared/types/pretalx'
 import type { SessionSummary } from '#shared/types/session'
 import pretalxData from '#server/utils/pretalx'
-import { parseAnswer, parseSlot, parseSpeaker, parseType } from '#server/utils/pretalx/parser'
+import { parseAnswer, parseDifficulty, parseSlot, parseSpeaker, parseTags, parseTrack, parseType } from '#server/utils/pretalx/parser'
 
 export default defineEventHandler(async () => {
   const data = await pretalxData()
@@ -30,6 +30,8 @@ export default defineEventHandler(async () => {
         start: slot.start,
         end: slot.end,
         language: answers.language,
+        difficulty: parseDifficulty(answers.difficulty),
+        track: parseTrack(submission.track, data),
         speakers,
         zh: {
           title: submission.title,
@@ -41,7 +43,7 @@ export default defineEventHandler(async () => {
           describe: answers.enDesc || submission.abstract,
           type: type.name.en || type.name['zh-hans'],
         },
-        tags: [],
+        tags: parseTags(submission.tags, data),
         uri: `https://coscup.org/2026/session/${submission.code}`,
       }
     })

--- a/server/api/session/index.get.ts
+++ b/server/api/session/index.get.ts
@@ -1,7 +1,7 @@
 import type { Submission } from '#shared/types/pretalx'
 import type { SessionSummary } from '#shared/types/session'
 import pretalxData from '#server/utils/pretalx'
-import { parseAnswer, parseDifficulty, parseSlot, parseSpeaker, parseTags, parseTrack, parseType } from '#server/utils/pretalx/parser'
+import { parseAnswer, parseSlot, parseSpeaker, parseTags, parseTrack, parseType } from '#server/utils/pretalx/parser'
 
 export default defineEventHandler(async () => {
   const data = await pretalxData()
@@ -30,7 +30,6 @@ export default defineEventHandler(async () => {
         start: slot.start,
         end: slot.end,
         language: answers.language,
-        difficulty: parseDifficulty(answers.difficulty),
         track: parseTrack(submission.track, data),
         speakers,
         zh: {
@@ -43,7 +42,7 @@ export default defineEventHandler(async () => {
           describe: answers.enDesc || submission.abstract,
           type: type.name.en || type.name['zh-hans'],
         },
-        tags: parseTags(submission.tags, data),
+        tags: parseTags(submission.tags, data, parseDifficulty(answers.difficulty)),
         uri: `https://coscup.org/2026/session/${submission.code}`,
       }
     })

--- a/server/api/session/index.get.ts
+++ b/server/api/session/index.get.ts
@@ -1,7 +1,7 @@
 import type { Submission } from '#shared/types/pretalx'
 import type { SessionSummary } from '#shared/types/session'
 import pretalxData from '#server/utils/pretalx'
-import { parseAnswer, parseSlot, parseSpeaker, parseTags, parseTrack, parseType } from '#server/utils/pretalx/parser'
+import { parseAnswer, parseDifficulty, parseSlot, parseSpeaker, parseTags, parseTrack, parseType } from '#server/utils/pretalx/parser'
 
 export default defineEventHandler(async () => {
   const data = await pretalxData()

--- a/server/utils/opass/pretalxToOpass.ts
+++ b/server/utils/opass/pretalxToOpass.ts
@@ -36,7 +36,7 @@ export function pretalxToOpass(pretalxData: PretalxResult) {
           title: answer.enTitle || submission.title,
           describe: answer.enDesc || submission.abstract,
         },
-        tags: [],
+        tags: parseTags(submission.tags, pretalxData, parseDifficulty(answer.difficulty)),
         uri: `https://coscup.org/2026/session/${submission.code}`,
         co_write: null,
         qa: null,
@@ -111,8 +111,6 @@ export function pretalxToOpass(pretalxData: PretalxResult) {
       }
     })
     .filter((x): x is NonNullable<typeof x> => x !== null)
-
-  // TODO: tags
 
   return { sessions, speakers, session_types: types, rooms }
 }

--- a/server/utils/opass/pretalxToOpass.ts
+++ b/server/utils/opass/pretalxToOpass.ts
@@ -1,5 +1,5 @@
 import type { PretalxResult, Room, Speaker, Submission, SubmissionType } from '#shared/types/pretalx'
-import { parseAnswer, parseSlot } from '#server/utils/pretalx/parser'
+import { parseAnswer, parseDifficulty, parseSlot, parseTags } from '#server/utils/pretalx/parser'
 
 export function pretalxToOpass(pretalxData: PretalxResult) {
   const speakerIds: Set<Speaker['code']> = new Set()

--- a/server/utils/pretalx/index.ts
+++ b/server/utils/pretalx/index.ts
@@ -9,13 +9,15 @@ export default defineCachedFunction(
       throw createError('Missing NUXT_PRETALX_API_URL or NUXT_PRETALX_API_TOKEN environment variable')
     }
 
-    const [submissions, submissionTypes, speakers, rooms, answers, slots] = await Promise.all([
+    const [submissions, submissionTypes, speakers, rooms, answers, slots, tracks, tags] = await Promise.all([
       fetchPretalxTable('submissions'),
       fetchPretalxTable('submission-types'),
       fetchPretalxTable('speakers'),
       fetchPretalxTable('rooms'),
       fetchPretalxTable('answers'),
       fetchPretalxTable('slots'),
+      fetchPretalxTable('tracks'),
+      fetchPretalxTable('tags'),
     ])
 
     return {
@@ -24,6 +26,8 @@ export default defineCachedFunction(
       rooms,
       answers,
       slots,
+      tracks,
+      tags,
       'submission-types': submissionTypes,
     } satisfies PretalxResult
   },

--- a/server/utils/pretalx/parser.ts
+++ b/server/utils/pretalx/parser.ts
@@ -1,5 +1,5 @@
-import type { Answer, PretalxResult, Room, Slot, Submission, SubmissionType } from '#shared/types/pretalx'
-import type { SessionSpeaker } from '#shared/types/session'
+import type { Answer, PretalxResult, Room, Slot, Submission, SubmissionType, Track } from '#shared/types/pretalx'
+import type { SessionDifficulty, SessionSpeaker, SessionTrack } from '#shared/types/session'
 
 // 對應 pretalx 的問題 ID。
 // key 為系統內使用的欄位名稱，value 為 pretalx 的 question id。
@@ -24,6 +24,21 @@ const QUESTION_MAP = {
 type QuestionKey = keyof typeof QUESTION_MAP
 type ParsedAnswer = Partial<Record<QuestionKey, string>>
 type ParsedSlot = Omit<Slot, 'room'> & { room?: Room }
+
+// 議程難度正規化表。pretalx 的難度欄位是投稿者自由填寫的自訂問題答案，
+// 各種寫法（中英文、大小寫）都收斂成統一的英文 enum，方便前端對應翻譯。
+const DIFFICULTY_GENERALIZE_MAP: Record<string, SessionDifficulty> = {
+  初學者: 'Elementary',
+  入門: 'Elementary',
+  中階: 'Intermediate',
+  進階: 'Advanced',
+  專業: 'Professional',
+  Beginner: 'Elementary',
+  Elementary: 'Elementary',
+  Intermediate: 'Intermediate',
+  Advanced: 'Advanced',
+  Professional: 'Professional',
+}
 
 export function parseAnswer(answers: Answer['id'][], pretalxData: PretalxResult): ParsedAnswer {
   const answerMap = pretalxData.answers.map
@@ -110,4 +125,36 @@ export function parseType(typeId: SubmissionType['id'], pretalxData: PretalxResu
   }
 
   return typeMap[typeId]
+}
+
+export function parseTrack(trackId: Submission['track'], pretalxData: PretalxResult): SessionTrack | undefined {
+  if (trackId == null) {
+    return undefined
+  }
+
+  const track: Track | undefined = pretalxData.tracks.map[trackId]
+
+  if (!track) {
+    return undefined
+  }
+
+  return { id: track.id, name: track.name }
+}
+
+export function parseTags(tagIds: Submission['tags'], pretalxData: PretalxResult): string[] {
+  const tagMap = pretalxData.tags.map
+
+  return tagIds
+    .map((tagId) => tagMap[tagId])
+    .filter((tag) => tag !== undefined)
+    .map((tag) => tag.tag)
+}
+
+// 將投稿者填寫的難度原始字串正規化成統一的英文 enum，無法對應時回傳 undefined。
+export function parseDifficulty(difficulty: string | undefined): SessionDifficulty | undefined {
+  if (!difficulty) {
+    return undefined
+  }
+
+  return DIFFICULTY_GENERALIZE_MAP[difficulty.trim()]
 }

--- a/server/utils/pretalx/parser.ts
+++ b/server/utils/pretalx/parser.ts
@@ -25,8 +25,7 @@ type QuestionKey = keyof typeof QUESTION_MAP
 type ParsedAnswer = Partial<Record<QuestionKey, string>>
 type ParsedSlot = Omit<Slot, 'room'> & { room?: Room }
 
-// 議程難度正規化表。pretalx 的難度欄位是投稿者自由填寫的自訂問題答案，
-// 各種寫法（中英文、大小寫）都收斂成統一的英文 enum，方便前端對應翻譯。
+// 議程難度正規化表。pretalx 的難度欄位是一個有固定選項的自訂問題答案。
 const DIFFICULTY_GENERALIZE_MAP: Record<string, SessionDifficulty> = {
   初學者: 'Elementary',
   入門: 'Elementary',

--- a/server/utils/pretalx/parser.ts
+++ b/server/utils/pretalx/parser.ts
@@ -1,4 +1,4 @@
-import type { Answer, PretalxResult, Room, Slot, Submission, SubmissionType, Track } from '#shared/types/pretalx'
+import type { Answer, PretalxResult, Room, Slot, Submission, SubmissionType, Tag, Track } from '#shared/types/pretalx'
 import type { SessionDifficulty, SessionSpeaker, SessionTrack } from '#shared/types/session'
 
 // 對應 pretalx 的問題 ID。
@@ -146,7 +146,7 @@ export function parseTags(tagIds: Submission['tags'], pretalxData: PretalxResult
 
   return tagIds
     .map((tagId) => tagMap[tagId])
-    .filter((tag) => tag !== undefined)
+    .filter((tag): tag is Tag => tag !== undefined && tag.is_public)
     .map((tag) => tag.tag)
 }
 

--- a/server/utils/pretalx/parser.ts
+++ b/server/utils/pretalx/parser.ts
@@ -141,13 +141,17 @@ export function parseTrack(trackId: Submission['track'], pretalxData: PretalxRes
   return { id: track.id, name: track.name }
 }
 
-export function parseTags(tagIds: Submission['tags'], pretalxData: PretalxResult): string[] {
+// 解析議程標籤，並把正規化後的難度（若有）一併併入標籤清單，
+// 讓難度成為標籤的一部分而非獨立欄位。
+export function parseTags(tagIds: Submission['tags'], pretalxData: PretalxResult, difficulty?: SessionDifficulty): string[] {
   const tagMap = pretalxData.tags.map
 
-  return tagIds
+  const tags = tagIds
     .map((tagId) => tagMap[tagId])
     .filter((tag): tag is Tag => tag !== undefined && tag.is_public)
     .map((tag) => tag.tag)
+
+  return difficulty ? [difficulty, ...tags] : tags
 }
 
 // 將投稿者填寫的難度原始字串正規化成統一的英文 enum，無法對應時回傳 undefined。

--- a/shared/types/pretalx.ts
+++ b/shared/types/pretalx.ts
@@ -7,6 +7,8 @@ export const PRETALX_TABLES = [
   'rooms',
   'answers',
   'slots',
+  'tracks',
+  'tags',
 ] as const
 export const PretalxTableSchema = z.enum(PRETALX_TABLES)
 
@@ -51,6 +53,19 @@ export const RoomSchema = z.object({
   description: PretalxLocaleSchema.nullable(),
 })
 
+export const TrackSchema = z.object({
+  id: z.number(),
+  name: PretalxLocaleSchema,
+  description: PretalxLocaleSchema.nullable().optional(),
+})
+
+export const TagSchema = z.object({
+  id: z.number(),
+  tag: z.string(),
+  description: PretalxLocaleSchema.nullable().optional(),
+  color: z.string().optional(),
+})
+
 export const AnswerSchema = z.object({
   id: z.number(),
   question: z.number(),
@@ -75,6 +90,8 @@ export const PRETALX_TABLE_SCHEMAS = {
   'rooms': RoomSchema,
   'answers': AnswerSchema,
   'slots': SlotSchema,
+  'tracks': TrackSchema,
+  'tags': TagSchema,
 } as const
 
 export type PretalxTable = z.infer<typeof PretalxTableSchema>
@@ -85,6 +102,8 @@ export type Speaker = z.infer<typeof SpeakerSchema>
 export type Room = z.infer<typeof RoomSchema>
 export type Answer = z.infer<typeof AnswerSchema>
 export type Slot = z.infer<typeof SlotSchema>
+export type Track = z.infer<typeof TrackSchema>
+export type Tag = z.infer<typeof TagSchema>
 export type TableTypeMap = {
   [K in PretalxTable]: z.infer<(typeof PRETALX_TABLE_SCHEMAS)[K]>
 }

--- a/shared/types/pretalx.ts
+++ b/shared/types/pretalx.ts
@@ -64,6 +64,7 @@ export const TagSchema = z.object({
   tag: z.string(),
   description: PretalxLocaleSchema.nullable().optional(),
   color: z.string().optional(),
+  is_public: z.boolean(),
 })
 
 export const AnswerSchema = z.object({

--- a/shared/types/session.ts
+++ b/shared/types/session.ts
@@ -19,12 +19,26 @@ const SessionContentSchema = z.object({
   type: z.string(),
 })
 
+export const SessionDifficultySchema = z.enum([
+  'Elementary',
+  'Intermediate',
+  'Advanced',
+  'Professional',
+])
+
+export const SessionTrackSchema = z.object({
+  id: z.number(),
+  name: PretalxLocaleSchema,
+})
+
 export const SessionSummarySchema = z.object({
   id: z.string(),
   room: PretalxLocaleSchema.optional(),
   start: z.string().nullable().optional(),
   end: z.string().nullable().optional(),
   language: z.string().optional(),
+  difficulty: SessionDifficultySchema.optional(),
+  track: SessionTrackSchema.optional(),
   speakers: z.array(SessionSpeakerSchema),
   zh: SessionContentSchema,
   en: SessionContentSchema,
@@ -40,5 +54,7 @@ export const SessionDetailSchema = SessionSummarySchema.extend({
 })
 
 export type SessionSpeaker = z.infer<typeof SessionSpeakerSchema>
+export type SessionDifficulty = z.infer<typeof SessionDifficultySchema>
+export type SessionTrack = z.infer<typeof SessionTrackSchema>
 export type SessionSummary = z.infer<typeof SessionSummarySchema>
 export type SessionDetail = z.infer<typeof SessionDetailSchema>

--- a/shared/types/session.ts
+++ b/shared/types/session.ts
@@ -37,7 +37,6 @@ export const SessionSummarySchema = z.object({
   start: z.string().nullable().optional(),
   end: z.string().nullable().optional(),
   language: z.string().optional(),
-  difficulty: SessionDifficultySchema.optional(),
   track: SessionTrackSchema.optional(),
   speakers: z.array(SessionSpeakerSchema),
   zh: SessionContentSchema,


### PR DESCRIPTION
Closes #171.

## Summary

`/api/session` 先前把 `tags` 寫死成空陣列，且沒有 `track` 欄位。本 PR 依照 issue #171 的提案，仿照 2025 的做法把這些補上，並把難度（difficulty）正規化後併入 `tags`，而非獨立成一個欄位：

- **新增 tracks / tags 兩張 Pretalx table 的抓取與 schema** — `PRETALX_TABLES` 加入 `tracks`、`tags`，新增 `TrackSchema`、`TagSchema`（`getPretalxItemKey` 以 `id` 為 key，直接相容）。`TagSchema` 帶 `is_public`，僅公開標籤會被輸出。
- **新增 parser** — `parseTrack`（submission.track id → `{ id, name }` 多語）、`parseDifficulty`（把投稿者填寫的難度原始字串正規化成 `Elementary`/`Intermediate`/`Advanced`/`Professional` enum）、`parseTags`（submission.tags id[] → 公開 tag 名稱 `string[]`，並把正規化後的難度 prepend 到清單最前面）。
- **三個輸出點帶上新結構** — `index.get.ts`、`[id]/index.get.ts` 與 opass.json（`pretalxToOpass`）都帶上 `track`，並用 `parseTags(..., parseDifficulty(...))` 取代寫死的 `tags`。
- **schema 調整** — `SessionSummarySchema` 新增 `track`，`tags` 內容改為實際 tag 名稱（含難度）；不再有獨立的 `difficulty` 欄位。

| 項目 | 來源 | 處理 |
|---|---|---|
| `track` | submission.track（id）→ tracks table | 輸出 `{ id, name }`（多語） |
| `tags` | submission.tags（id[]）→ tags table + answers Q270 | 公開 tag 名稱 `string[]`，難度正規化成英文 enum 後併入清單最前 |

## Example output

單筆 session（難度作為 tag 的第一項）：

```json
{
  "id": "3LWSX3",
  "language": "中文",
  "track": {
    "id": 461,
    "name": { "en": "Main Session Track", "zh-hans": "" }
  },
  "tags": ["Elementary", "原綜合軌"]
}
```

- 難度正規化值：`["Advanced", "Elementary", "Intermediate"]`，作為 tag 併入 `tags`
- 其他 tags 範例：`"early-bird"`, `"program-invitation"`, `"cn"`, `"Misc - DevOps"`, `"原綜合軌"`
- `track.name.en` 範例：`"Cloud Native Days Taipei"`, `"Golang Taiwan"`, `"Data Infrastructure"`

單筆詳細端點 `/api/session/{id}` 與 opass.json 同樣帶上 `track`，並把難度併入 `tags`。

## Notes

- `pnpm lint` 與 `pnpm typecheck` 皆通過。
- 僅公開（`is_public`）的 tag 會被輸出，避免把 organizer-only 標籤暴露到公開 API。
- 測試用的 2025 資料 locale key 為 `zh-hant`，而既有的 `PretalxLocaleSchema` 只取 `en` 與 `zh-hans`（room/type 名稱也是相同行為），因此 2025 資料的 `track.name.zh-hans` 會是空字串；2026 正式資料若採 `zh-hans` 則會正常填入。此為既有、跨欄位一致的設計，本 PR 未更動。

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEyZKJJtSf8Hm8vDLpqiZZ)_
