### PR TITLE
feat: host sponsor image in GitHub Pages

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -155,4 +155,8 @@ export default defineNuxtConfig({
       page_title: 'COSCUP 2026',
     },
   },
+
+  image: {
+    domains: ['drive.usercontent.google.com'],
+  },
 })

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -158,5 +158,8 @@ export default defineNuxtConfig({
 
   image: {
     domains: ['drive.usercontent.google.com'],
+    alias: {
+      gdrive: 'https://drive.usercontent.google.com',
+    },
   },
 })

--- a/server/api/sponsor.get.ts
+++ b/server/api/sponsor.get.ts
@@ -3,7 +3,7 @@ import { fetchSheet } from '../utils/sheets'
 function transformImageUrl(source: string) {
   if (source.startsWith('https://drive.google.com/file/d/')) {
     const id = source.split('/')[5]
-    const url = `https://drive.google.com/thumbnail?id=${id}`
+    const url = `https://drive.usercontent.google.com/download?id=${id}&export=view`
 
     return url
   }

--- a/server/api/sponsor.get.ts
+++ b/server/api/sponsor.get.ts
@@ -3,7 +3,7 @@ import { fetchSheet } from '../utils/sheets'
 function transformImageUrl(source: string) {
   if (source.startsWith('https://drive.google.com/file/d/')) {
     const id = source.split('/')[5]
-    const url = `https://drive.usercontent.google.com/download?id=${id}&export=view`
+    const url = `/gdrive/download?id=${id}&export=view`
 
     return url
   }


### PR DESCRIPTION
現在使用的是連到 Google Drive 的 Thumbnail API，容易受到 Google Drive 內部設定的影響（如 #177、COSCUP/2025#232）。

因此，這個 PR：

(1) 使用 Google Drive「直鏈下載」API 取得贊助商的原始圖檔，比 Thumbnail 更清晰
(2) 交由 NuxtImg 的 ipx 進行壓縮和倍數縮放，並將這部分的素材放在 GitHub Pages 裡面

---

> [!CAUTION]
>
> 因為 static web server 對於 `ipx` 路徑的處理規則，導致目前這個 PR 沒有如預期運作。正在調查怎麼解決……
>
> ```
> http://localhost:3000/_ipx/_/gdrive/download%3Fid=1yH7NylNqSWfUxUZr_B564UW27Ij707km%26export=view
> ```
>
> Output path:
>
> ```
> .output/public/_ipx/_/gdrive/download%3Fid=1yH7NylNqSWfUxUZr_B564UW27Ij707km%26export=view
> ```