### PR TITLE
fix: filter public tags only in pretalx parser

### DIFF
--- a/server/utils/pretalx/parser.ts
+++ b/server/utils/pretalx/parser.ts
@@ -1,4 +1,4 @@
-import type { Answer, PretalxResult, Room, Slot, Submission, SubmissionType, Track } from '#shared/types/pretalx'
+import type { Answer, PretalxResult, Room, Slot, Submission, SubmissionType, Tag, Track } from '#shared/types/pretalx'
 import type { SessionDifficulty, SessionSpeaker, SessionTrack } from '#shared/types/session'
 
 // 對應 pretalx 的問題 ID。
@@ -146,7 +146,7 @@ export function parseTags(tagIds: Submission['tags'], pretalxData: PretalxResult
 
   return tagIds
     .map((tagId) => tagMap[tagId])
-    .filter((tag) => tag !== undefined)
+    .filter((tag): tag is Tag => tag !== undefined && tag.is_public)
     .map((tag) => tag.tag)
 }
 

--- a/shared/types/pretalx.ts
+++ b/shared/types/pretalx.ts
@@ -64,6 +64,7 @@ export const TagSchema = z.object({
   tag: z.string(),
   description: PretalxLocaleSchema.nullable().optional(),
   color: z.string().optional(),
+  is_public: z.boolean(),
 })
 
 export const AnswerSchema = z.object({


### PR DESCRIPTION
## Summary
Updated the pretalx tag parser to only include public tags when processing submission tags, and added the `is_public` field to the Tag schema.

## Key Changes
- Added `is_public: z.boolean()` field to the `TagSchema` in `shared/types/pretalx.ts` to represent whether a tag is publicly visible
- Updated the `parseTags()` function in `server/utils/pretalx/parser.ts` to filter tags based on their `is_public` status, ensuring only public tags are returned
- Improved type safety by using a type guard in the filter predicate: `(tag): tag is Tag => tag !== undefined && tag.is_public`
- Added `Tag` to the imports in the parser file to support the type guard

## Implementation Details
The filter now checks both that the tag exists (`tag !== undefined`) and that it is marked as public (`tag.is_public`), preventing private tags from being included in the parsed results. The type guard ensures TypeScript correctly narrows the type after filtering.

https://claude.ai/code/session_019ZBZWtrbxkByrrWGTvpV37