### PR TITLE
fix: correct sponsor translation key typo

### DIFF
--- a/app/components/shared/CpSponsorFooter.vue
+++ b/app/components/shared/CpSponsorFooter.vue
@@ -81,5 +81,5 @@ en:
     bronze: Bronze
     friend: Friend
     community: Community Partner
-    thinks: Special Thanks
+    thanks: Special Thanks
 </i18n>


### PR DESCRIPTION
Closes #191.

## Summary
- Corrected the i18n key typo from \'thinks\' to \'thanks\' in \'app/components/shared/CpSponsorFooter.vue\'.
- This keeps English sponsor level lookup aligned with the existing  reference in the Traditional Chinese locale block.

## Testing
- pnpm install --frozen-lockfile
- pnpm lint