### PR TITLE
fix: keep the session filter dropdown above the schedule grid

### DIFF
--- a/app/components/content/LeafletMap.vue
+++ b/app/components/content/LeafletMap.vue
@@ -32,7 +32,7 @@ onMounted(async () => {
 <template>
   <div
     ref="mapEl"
-    class="not-prose h-100"
+    class="not-prose h-100 isolate"
   />
 </template>
 

--- a/app/components/feature/CpSessionFilterDropdown.vue
+++ b/app/components/feature/CpSessionFilterDropdown.vue
@@ -106,7 +106,7 @@ function clearSelection() {
 
     <div
       v-if="open"
-      class="mt-1 p-3 border border-gray-300 rounded-md bg-gray-50 flex flex-col gap-2 max-w-[calc(100vw-32px)] w-72 shadow-md left-1/2 absolute z-30 sm:p-2 sm:gap-1 sm:max-w-[calc(100vw-64px)] -translate-x-1/2 sm:translate-x-0 sm:left-0"
+      class="mt-1 p-3 border border-gray-300 rounded-md bg-gray-50 flex flex-col gap-2 max-w-[calc(100vw-32px)] w-72 shadow-md left-1/2 absolute z-dropdown sm:p-2 sm:gap-1 sm:max-w-[calc(100vw-64px)] -translate-x-1/2 sm:translate-x-0 sm:left-0"
     >
       <CpTextField
         v-model="searchQuery"

--- a/app/components/feature/CpSessionList.vue
+++ b/app/components/feature/CpSessionList.vue
@@ -34,12 +34,12 @@ const times = Object.keys(sessions.value).sort()
 </script>
 
 <template>
-  <div class="flex flex-col gap-6 w-[var(--viewport-width,100vw)]">
+  <div class="flex flex-col gap-6 w-[var(--viewport-width,100vw)] isolate">
     <section
       v-for="time in times"
       :key="time"
     >
-      <h3 class="text-lg text-primary-400 font-medium mb-2 py-1 bg-white top-0 sticky z-1">
+      <h3 class="text-lg text-primary-400 font-medium mb-2 py-1 bg-white top-0 sticky z-content">
         {{ time }}
       </h3>
       <div class="flex flex-col gap-2">

--- a/app/components/feature/CpSessionTable.vue
+++ b/app/components/feature/CpSessionTable.vue
@@ -122,7 +122,7 @@ const showRealtimeLine = computed(() => {
 <template>
   <div
     ref="containerRef"
-    class="border border-gray-200 rounded-xl grid relative overflow-clip"
+    class="border border-gray-200 rounded-xl grid relative overflow-clip isolate"
     :class="isDragging ? 'cursor-grabbing select-none' : 'cursor-grab'"
     :style="{
       gridTemplateColumns: `4.5rem repeat(${rooms.length}, ${columnWidth}px)`,
@@ -130,7 +130,7 @@ const showRealtimeLine = computed(() => {
     }"
   >
     <div
-      class="border-b border-gray-200 bg-gray-50 left-0 top-0 sticky z-20"
+      class="border-b border-gray-200 bg-gray-50 left-0 top-0 sticky z-sticky"
       :style="{
         'grid-row': 1,
         'grid-column': 1,
@@ -140,7 +140,7 @@ const showRealtimeLine = computed(() => {
     <div
       v-for="(room, i) in rooms"
       :key="room"
-      class="text-sm text-primary-400 font-medium border-b border-gray-200 bg-gray-50 flex items-center top-0 justify-center sticky z-20"
+      class="text-sm text-primary-400 font-medium border-b border-gray-200 bg-gray-50 flex items-center top-0 justify-center sticky z-sticky"
       :style="{
         'grid-row': 1,
         'grid-column': i + 2,
@@ -154,7 +154,7 @@ const showRealtimeLine = computed(() => {
       :key="label.label"
     >
       <div
-        class="text-xs text-gray-400 pr-2 pt-0.5 text-right border-t border-gray-100 bg-gray-50 flex items-start left-0 justify-center sticky z-10"
+        class="text-xs text-gray-400 pr-2 pt-0.5 text-right border-t border-gray-100 bg-gray-50 flex items-start left-0 justify-center sticky z-content"
         :style="{
           'grid-row': `${label.row} / ${label.row + 30 / interval}`,
           'grid-column': 1,
@@ -198,7 +198,7 @@ const showRealtimeLine = computed(() => {
     <ClientOnly>
       <div
         v-if="showRealtimeLine"
-        class="border-t-1 border-red-500 w-full pointer-events-none left-0 absolute z-10"
+        class="border-t-1 border-red-500 w-full pointer-events-none left-0 absolute z-content"
         :style="{ top: `${nowLineTop}px` }"
       />
     </ClientOnly>

--- a/app/components/shared/CpDropdown.vue
+++ b/app/components/shared/CpDropdown.vue
@@ -34,7 +34,7 @@ onClickOutside(containerRef, () => {
     </button>
     <ul
       v-if="open"
-      class="mt-1 py-1 border border-gray-200 rounded-md bg-white min-w-32 shadow-md left-0 absolute z-1500"
+      class="mt-1 py-1 border border-gray-200 rounded-md bg-white min-w-32 shadow-md left-0 absolute z-dropdown"
     >
       <li
         v-for="item in props.items"

--- a/app/components/shared/CpNavbar.vue
+++ b/app/components/shared/CpNavbar.vue
@@ -107,14 +107,14 @@ function closeMenu() {
     <!-- Mobile backdrop -->
     <div
       v-if="menuOpen"
-      class="bg-black/30 inset-0 top-16 fixed z-1200 sm:hidden"
+      class="bg-black/30 inset-0 top-16 fixed z-modal sm:hidden"
       @click="closeMenu"
     />
 
     <!-- Mobile dropdown -->
     <div
       v-if="menuOpen"
-      class="border-b border-gray-300 bg-white h-max shadow-md left-0 right-0 top-16 absolute z-1500 sm:hidden"
+      class="border-b border-gray-300 bg-white h-max shadow-md left-0 right-0 top-16 absolute z-toast sm:hidden"
     >
       <ul class="py-2 flex flex-col">
         <template

--- a/app/components/shared/CpPopup.vue
+++ b/app/components/shared/CpPopup.vue
@@ -23,7 +23,7 @@ onClickOutside(target, () => toggle(false))
     <Teleport to="body">
       <div
         v-show="isOpen"
-        class="bg-black/50 flex items-center inset-0 justify-center fixed z-50"
+        class="bg-black/50 flex items-center inset-0 justify-center fixed z-modal"
       >
         <transition
           enter-active-class="ease-out duration-100"

--- a/app/layouts/session-table.vue
+++ b/app/layouts/session-table.vue
@@ -19,7 +19,7 @@ onUnmounted(() => {
 
 <template>
   <div class="w-max">
-    <CpNavbar class="w-[var(--viewport-width,100vw)] left-0 sticky z-10" />
+    <CpNavbar class="w-[var(--viewport-width,100vw)] left-0 sticky z-sticky" />
     <main class="w-max">
       <slot />
     </main>

--- a/app/pages/session.vue
+++ b/app/pages/session.vue
@@ -66,7 +66,7 @@ definePageMeta({
           </div>
 
           <!-- FilterBar -->
-          <div class="p-4 flex flex-col gap-3 w-[var(--viewport-width,100vw)] items-stretch left-0 sticky z-10 sm:flex-row sm:items-center sm:justify-between">
+          <div class="p-4 flex flex-col gap-3 w-[var(--viewport-width,100vw)] items-stretch left-0 sticky z-sticky sm:flex-row sm:items-center sm:justify-between">
             <div class="flex shrink-0 gap-3 items-center justify-center sm:justify-start">
               <div class="rounded-md bg-gray-200 h-12 w-18 animate-pulse sm:h-9" />
               <div class="rounded-md bg-gray-200 h-12 w-18 animate-pulse sm:h-9" />
@@ -84,7 +84,7 @@ definePageMeta({
         <div class="flex flex-col">
           <CpSessionDaySelector
             v-model="selectedDay"
-            class="w-[var(--viewport-width,100vw)] bottom-0 left-0 order-last sticky z-10 sm:bottom-auto sm:order-none"
+            class="w-[var(--viewport-width,100vw)] bottom-0 left-0 order-last sticky z-sticky sm:bottom-auto sm:order-none"
             :days="days"
           />
 
@@ -92,7 +92,7 @@ definePageMeta({
             v-model:search-query="searchQuery"
             v-model:selected-room-ids="selectedRoomIds"
             v-model:selected-tag-ids="selectedTagIds"
-            class="p-4 left-0 sticky z-10"
+            class="p-4 left-0 sticky z-sticky"
             :room-options="roomOptions"
             :tag-options="tagOptions"
           />

--- a/app/pages/session/[id].vue
+++ b/app/pages/session/[id].vue
@@ -71,7 +71,7 @@ onUnmounted(() => {
   <div
     :aria-label="sessionInfo?.title"
     aria-modal="true"
-    class="bg-black/50 inset-0 fixed z-50"
+    class="bg-black/50 inset-0 fixed z-modal"
     role="dialog"
     @click.self="close"
   >
@@ -81,7 +81,7 @@ onUnmounted(() => {
       </div>
 
       <div class="p-3 h-full w-full overflow-y-auto">
-        <div class="flex top-0 justify-end sticky z-10">
+        <div class="flex top-0 justify-end sticky z-content">
           <button
             aria-label="close"
             class="text-gray-500 rounded-full flex h-8 w-8 transition-colors items-center justify-center hover:bg-gray-100"

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -7,7 +7,12 @@ import presetThemes from 'unocss-preset-theme'
 
 export default defineConfig({
   shortcuts: {
-    icon: '-align-0.125em',
+    'icon': '-align-0.125em',
+    'z-content': 'z-10', // isolated 容器內的內容層（表格表頭、列表標題）
+    'z-sticky': 'z-20', // 頁面固定元素（導覽列、日期選擇器、篩選列）
+    'z-dropdown': 'z-30', // 下拉與彈出選單
+    'z-modal': 'z-40', // 全螢幕遮罩與對話框
+    'z-toast': 'z-50', // 最上層（手機選單、通知）
   },
   extractors: [
     extractorMdc(),


### PR DESCRIPTION
Stacked on #172 (base branch: \`add-session-search-filters\`) — retarget to \`main\` once #172 merges.

Addresses https://github.com/COSCUP/2026/pull/172#discussion_r3381235899 and Riley's follow-up https://github.com/COSCUP/2026/pull/172#discussion_r3386596132.

## Problem

When a filter dropdown opens over the schedule grid on desktop, the sticky room/time headers in `CpSessionTable` (`z-20`) paint over the dropdown even though the dropdown itself is `z-30`.

**Root cause:** the filter bar is `sticky z-10`, which establishes a stacking context, so the dropdown's `z-30` is trapped at the bar's `z-10` level. `CpSessionTable`'s root (`relative overflow-clip`, `z-index: auto`) creates no stacking context, so its sticky headers share the page-level context and outrank the whole bar.

The bar was deliberately lowered to `z-10` so the session-detail modal backdrop (`fixed z-50`) stays above it — a constraint preserved here.

## Fix

1. **`isolation: isolate`** on the `CpSessionTable` and `CpSessionList` roots, so their internal sticky layers stay self-contained. The table then sits at the page level with `z-index: auto`, and the filter bar paints above it — without raising the bar past the modal backdrop.
2. **A semantic z-index scale** (10-increment) as UnoCSS shortcuts in `uno.config.ts`, with every raw `z-N` migrated to it for a single source of truth:

   | token | value | usage |
   |---|---|---|
   | `z-content` | 10 | in-content sticky inside an isolated container |
   | `z-sticky` | 20 | page sticky chrome (navbar, day selector, filter bar) |
   | `z-dropdown` | 30 | popovers / menus anchored to chrome |
   | `z-modal` | 40 | full-screen overlays / backdrops |
   | `z-toast` | 50 | top-most (nav mobile menu, future toasts) |

## Verification

- `pnpm typecheck` passes; `pnpm lint` clean on changed files.
- Desktop: filter dropdown renders fully above the sticky headers; session-detail modal backdrop still covers the bar.
- Mobile: dropdown opens above the session list; navbar hamburger menu still overlays the page.

<img width="3024" height="1898" alt="CleanShot 2026-06-10 at 18 35 07@2x" src="https://github.com/user-attachments/assets/9ec71437-6f24-46b0-a445-d3fdf38260d4" />
<img width="3024" height="1898" alt="CleanShot 2026-06-10 at 18 35 00@2x" src="https://github.com/user-attachments/assets/9a3b14c3-376d-4c59-bef8-0205b7d3d2d9" />
