### PR TITLE
feat: 議程軌詳細頁面

### DIFF
--- a/app/components/feature/CpSessionList.vue
+++ b/app/components/feature/CpSessionList.vue
@@ -34,8 +34,8 @@ const sessions = computed(() => {
         start: session.start!.slice(11, 16),
         end: session.end!.slice(11, 16),
         room: locale.value === 'zh'
-          ? (session.room?.['zh-hans'] || session.room?.en || '')
-          : (session.room?.en || session.room?.['zh-hans'] || ''),
+          ? (session.room?.['zh-hant'] || session.room?.en || '')
+          : (session.room?.en || session.room?.['zh-hant'] || ''),
         tags: [],
       })),
     (session) => session.start,

--- a/app/components/feature/CpTrackHeader.vue
+++ b/app/components/feature/CpTrackHeader.vue
@@ -12,7 +12,7 @@ const props = defineProps<{
 
 const { t } = useI18n()
 
-const selectedDay = defineModel<string>()
+const selectedDay = defineModel<string>({ required: true })
 
 function formatDayLabel(day: string) {
   return new Intl.DateTimeFormat('en-US', {
@@ -57,6 +57,7 @@ const activeDay = computed(() => selectedDay.value ?? props.days[0] ?? '')
         <button
           v-for="day in days"
           :key="day"
+          :aria-pressed="day === activeDay"
           class="text-sm font-medium px-3 py-1.5 border rounded-lg cursor-pointer transition-colors"
           :class="day === activeDay
             ? 'bg-primary-700 text-white border-primary-700'
@@ -77,7 +78,7 @@ const activeDay = computed(() => selectedDay.value ?? props.days[0] ?? '')
           class="h-4 w-4"
           name="tabler:map-pin"
         />
-        <span>{{ rooms.join('、') }}</span>
+        <span>{{ rooms.join(t('separator')) }}</span>
       </div>
 
       <!-- 社群連結 -->
@@ -110,8 +111,10 @@ const activeDay = computed(() => selectedDay.value ?? props.days[0] ?? '')
     count: '{count} sessions'
     days: 'Days'
     links: 'Community'
+    separator: ', '
   zh:
     count: '{count} 場議程'
     days: '議程日數'
     links: '社群連結'
+    separator: '、'
 </i18n>

--- a/app/components/feature/CpTrackHeader.vue
+++ b/app/components/feature/CpTrackHeader.vue
@@ -1,0 +1,117 @@
+<script setup lang="ts">
+import { useI18n } from '#imports'
+
+const props = defineProps<{
+  title: string
+  subtitle?: string
+  count: number
+  days: string[]
+  rooms: string[]
+  links: { label: string, url: string }[]
+}>()
+
+const { t } = useI18n()
+
+const selectedDay = defineModel<string>()
+
+function formatDayLabel(day: string) {
+  return new Intl.DateTimeFormat('en-US', {
+    day: 'numeric',
+    month: 'short',
+    timeZone: 'Asia/Taipei',
+  })
+    .format(new Date(`${day}T00:00:00+08:00`))
+    .replace(' ', '.')
+}
+
+const activeDay = computed(() => selectedDay.value ?? props.days[0] ?? '')
+</script>
+
+<template>
+  <header class="flex flex-col gap-5">
+    <div class="flex gap-4 items-start justify-between">
+      <div class="flex flex-col gap-2">
+        <h1 class="text-3xl text-primary-700 font-bold sm:text-4xl">
+          {{ title }}
+        </h1>
+        <p
+          v-if="subtitle"
+          class="text-gray-500"
+        >
+          {{ subtitle }}
+        </p>
+      </div>
+
+      <span class="text-sm text-gray-600 font-medium px-3 py-1.5 rounded-full bg-gray-100 flex-shrink-0 whitespace-nowrap">
+        {{ t('count', { count }) }}
+      </span>
+    </div>
+
+    <div class="text-sm flex flex-wrap gap-x-6 gap-y-3 items-center">
+      <!-- 議程日數 -->
+      <div
+        v-if="days.length"
+        class="flex gap-2 items-center"
+      >
+        <span class="text-gray-500">{{ t('days') }}</span>
+        <button
+          v-for="day in days"
+          :key="day"
+          class="text-sm font-medium px-3 py-1.5 border rounded-lg cursor-pointer transition-colors"
+          :class="day === activeDay
+            ? 'bg-primary-700 text-white border-primary-700'
+            : 'bg-white text-gray-700 border-gray-300 hover:border-primary-400'"
+          type="button"
+          @click="selectedDay = day"
+        >
+          {{ formatDayLabel(day) }}
+        </button>
+      </div>
+
+      <!-- 教室 -->
+      <div
+        v-if="rooms.length"
+        class="text-gray-600 flex gap-1.5 items-center"
+      >
+        <Icon
+          class="h-4 w-4"
+          name="tabler:map-pin"
+        />
+        <span>{{ rooms.join('、') }}</span>
+      </div>
+
+      <!-- 社群連結 -->
+      <div
+        v-if="links.length"
+        class="flex flex-wrap gap-2 items-center"
+      >
+        <span class="text-gray-500">{{ t('links') }}</span>
+        <a
+          v-for="link in links"
+          :key="link.url"
+          class="text-sm text-white font-medium px-3 py-1.5 rounded-lg bg-primary-400 inline-flex gap-1.5 transition-colors items-center hover:bg-primary-500"
+          :href="link.url"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <Icon
+            class="h-4 w-4"
+            name="tabler:external-link"
+          />
+          {{ link.label }}
+        </a>
+      </div>
+    </div>
+  </header>
+</template>
+
+<i18n lang="yaml">
+  en:
+    count: '{count} sessions'
+    days: 'Days'
+    links: 'Community'
+  zh:
+    count: '{count} 場議程'
+    days: '議程日數'
+    links: '社群連結'
+</i18n>

--- a/app/components/feature/CpTrackSchedule.vue
+++ b/app/components/feature/CpTrackSchedule.vue
@@ -19,7 +19,7 @@ const CARD_GAP = 2 // 相鄰卡片間的細縫 px
 const DIFFICULTIES: SessionDifficulty[] = ['Elementary', 'Intermediate', 'Advanced', 'Professional']
 
 const localeKey = computed(() => (locale.value === 'zh' ? 'zh' : 'en'))
-const roomKey = computed(() => (localeKey.value === 'zh' ? 'zh-hans' : 'en') as 'zh-hans' | 'en')
+const roomKey = computed(() => (localeKey.value === 'zh' ? 'zh-hant' : 'en') as 'zh-hant' | 'en')
 
 function parseMinutes(iso: string) {
   const match = iso.match(/T(\d{2}):(\d{2})/)

--- a/app/components/feature/CpTrackSchedule.vue
+++ b/app/components/feature/CpTrackSchedule.vue
@@ -8,7 +8,7 @@ const { sessions } = defineProps<{
 }>()
 
 const { t, locale } = useI18n()
-const localePath = useLocalePath()
+const route = useRoute()
 
 // 時間軸尺寸。以「分鐘 → grid 列」為共同基準，刻度線與卡片同列才會對齊。
 const SLOT_MINUTES = 5 // 一列代表的分鐘數，對齊 Pretalx 排程粒度
@@ -24,7 +24,7 @@ const roomKey = computed(() => (localeKey.value === 'zh' ? 'zh-hans' : 'en') as 
 function parseMinutes(iso: string) {
   const match = iso.match(/T(\d{2}):(\d{2})/)
   if (!match) {
-    return 0
+    return null
   }
   return Number(match[1]) * 60 + Number(match[2])
 }
@@ -50,10 +50,16 @@ const range = computed(() => {
   let max = 18 * 60
   for (const session of sessions) {
     if (session.start) {
-      min = Math.min(min, parseMinutes(session.start))
+      const start = parseMinutes(session.start)
+      if (start !== null) {
+        min = Math.min(min, start)
+      }
     }
     if (session.end) {
-      max = Math.max(max, parseMinutes(session.end))
+      const end = parseMinutes(session.end)
+      if (end !== null) {
+        max = Math.max(max, end)
+      }
     }
   }
   return {
@@ -90,21 +96,28 @@ function roomSessions(room: string) {
   return sessions
     .filter((session) => roomName(session) === room && session.start && session.end)
     .map((session) => {
+      const startMins = parseMinutes(session.start!)
+      const endMins = parseMinutes(session.end!)
+      if (startMins === null || endMins === null) {
+        return null
+      }
+
       const difficulty = session.tags.find((tag): tag is SessionDifficulty =>
         (DIFFICULTIES as string[]).includes(tag))
 
       return {
         id: session.id,
-        startMins: parseMinutes(session.start!),
+        startMins,
         title: session[localeKey.value].title,
-        speaker: session.speakers.map((s) => s[localeKey.value].name).join('、'),
+        speaker: session.speakers.map((s) => s[localeKey.value].name).join(t('separator')),
         start: session.start!.slice(11, 16),
         end: session.end!.slice(11, 16),
         difficulty: difficulty ? t(`difficulty.${difficulty}`) : undefined,
-        rowStart: toRow(parseMinutes(session.start!)),
-        rowEnd: toRow(parseMinutes(session.end!)),
+        rowStart: toRow(startMins),
+        rowEnd: toRow(endMins),
       }
     })
+    .filter((session): session is NonNullable<typeof session> => session !== null)
     .sort((a, b) => a.startMins - b.startMins)
 }
 </script>
@@ -166,7 +179,7 @@ function roomSessions(room: string) {
             gridRow: `${session.rowStart} / ${session.rowEnd}`,
             paddingBottom: `${CARD_GAP}px`,
           }"
-          :to="localePath(`/session/${session.id}`)"
+          :to="{ query: { ...route.query, session: session.id } }"
         >
           <CpTrackSessionBlock
             :difficulty="session.difficulty"
@@ -191,6 +204,7 @@ function roomSessions(room: string) {
 <i18n lang="yaml">
   en:
     noSession: 'No sessions on this day.'
+    separator: ', '
     difficulty:
       Elementary: 'Elementary'
       Intermediate: 'Intermediate'
@@ -198,6 +212,7 @@ function roomSessions(room: string) {
       Professional: 'Professional'
   zh:
     noSession: '這天沒有議程。'
+    separator: '、'
     difficulty:
       Elementary: '入門'
       Intermediate: '中階'

--- a/app/components/feature/CpTrackSchedule.vue
+++ b/app/components/feature/CpTrackSchedule.vue
@@ -1,0 +1,206 @@
+<script setup lang="ts">
+import type { SessionDifficulty, SessionSummary } from '#shared/types/session'
+import { useI18n } from '#imports'
+import CpTrackSessionBlock from './CpTrackSessionBlock.vue'
+
+const { sessions } = defineProps<{
+  sessions: SessionSummary[]
+}>()
+
+const { t, locale } = useI18n()
+const localePath = useLocalePath()
+
+// 時間軸尺寸。以「分鐘 → grid 列」為共同基準，刻度線與卡片同列才會對齊。
+const SLOT_MINUTES = 5 // 一列代表的分鐘數，對齊 Pretalx 排程粒度
+const ROW_HEIGHT = 16 // 一列高度 px；30 分鐘 = 6 列 = 96px，容得下兩行標題＋講者＋時間
+const TIME_GUTTER = '2.75rem' // 左側時間欄寬度
+const CARD_GAP = 2 // 相鄰卡片間的細縫 px
+
+const DIFFICULTIES: SessionDifficulty[] = ['Elementary', 'Intermediate', 'Advanced', 'Professional']
+
+const localeKey = computed(() => (locale.value === 'zh' ? 'zh' : 'en'))
+const roomKey = computed(() => (localeKey.value === 'zh' ? 'zh-hans' : 'en') as 'zh-hans' | 'en')
+
+function parseMinutes(iso: string) {
+  const match = iso.match(/T(\d{2}):(\d{2})/)
+  if (!match) {
+    return 0
+  }
+  return Number(match[1]) * 60 + Number(match[2])
+}
+
+function formatHour(minutes: number) {
+  return `${Math.floor(minutes / 60)}:00`
+}
+
+function roomName(session: SessionSummary) {
+  return session.room?.[roomKey.value] || session.room?.en
+}
+
+const rooms = computed(() => {
+  const names = sessions
+    .map((session) => roomName(session))
+    .filter((name): name is string => Boolean(name))
+  return [...new Set(names)].sort()
+})
+
+// 涵蓋全部場次、往外取整到整點，最少 9:00–18:00。
+const range = computed(() => {
+  let min = 9 * 60
+  let max = 18 * 60
+  for (const session of sessions) {
+    if (session.start) {
+      min = Math.min(min, parseMinutes(session.start))
+    }
+    if (session.end) {
+      max = Math.max(max, parseMinutes(session.end))
+    }
+  }
+  return {
+    start: Math.floor(min / 60) * 60,
+    end: Math.ceil(max / 60) * 60,
+  }
+})
+
+const totalRows = computed(() => (range.value.end - range.value.start) / SLOT_MINUTES)
+
+// 分鐘 → grid 列（1 起算）。
+function toRow(minutes: number) {
+  return Math.round((minutes - range.value.start) / SLOT_MINUTES) + 1
+}
+
+const hourMarks = computed(() => {
+  const marks: { minutes: number, row: number }[] = []
+  for (let m = range.value.start; m <= range.value.end; m += 60) {
+    marks.push({ minutes: m, row: toRow(m) })
+  }
+  return marks
+})
+
+// 半點（如 11:30），畫虛線、不放標籤。
+const halfHourMarks = computed(() => {
+  const marks: { minutes: number, row: number }[] = []
+  for (let m = range.value.start + 30; m < range.value.end; m += 60) {
+    marks.push({ minutes: m, row: toRow(m) })
+  }
+  return marks
+})
+
+function roomSessions(room: string) {
+  return sessions
+    .filter((session) => roomName(session) === room && session.start && session.end)
+    .map((session) => {
+      const difficulty = session.tags.find((tag): tag is SessionDifficulty =>
+        (DIFFICULTIES as string[]).includes(tag))
+
+      return {
+        id: session.id,
+        startMins: parseMinutes(session.start!),
+        title: session[localeKey.value].title,
+        speaker: session.speakers.map((s) => s[localeKey.value].name).join('、'),
+        start: session.start!.slice(11, 16),
+        end: session.end!.slice(11, 16),
+        difficulty: difficulty ? t(`difficulty.${difficulty}`) : undefined,
+        rowStart: toRow(parseMinutes(session.start!)),
+        rowEnd: toRow(parseMinutes(session.end!)),
+      }
+    })
+    .sort((a, b) => a.startMins - b.startMins)
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-6">
+    <div
+      v-for="room in rooms"
+      :key="room"
+      class="border border-gray-200 rounded-2xl overflow-hidden"
+    >
+      <div class="text-primary-500 font-medium px-5 py-3 bg-primary-50 flex gap-2 items-center">
+        <Icon
+          class="h-4 w-4"
+          name="tabler:map-pin"
+        />
+        <span>{{ room }}</span>
+      </div>
+
+      <!-- 刻度線與卡片共用同一組 grid 列，故彼此對齊 -->
+      <div
+        class="px-5 py-4 grid"
+        :style="{
+          gridTemplateColumns: `${TIME_GUTTER} minmax(0, 1fr)`,
+          gridTemplateRows: `repeat(${totalRows}, ${ROW_HEIGHT}px)`,
+        }"
+      >
+        <!-- 整點：標籤＋實線 -->
+        <template
+          v-for="mark in hourMarks"
+          :key="`h-${mark.minutes}`"
+        >
+          <div
+            class="text-xs text-gray-400 pr-2 text-right self-start -translate-y-1/2"
+            :style="{ gridColumn: 1, gridRow: mark.row }"
+          >
+            {{ formatHour(mark.minutes) }}
+          </div>
+          <div
+            class="border-t border-gray-100 w-full self-start"
+            :style="{ gridColumn: 2, gridRow: mark.row }"
+          />
+        </template>
+
+        <!-- 半點：虛線 -->
+        <div
+          v-for="mark in halfHourMarks"
+          :key="`hh-${mark.minutes}`"
+          class="border-t border-gray-100 border-dashed w-full self-start"
+          :style="{ gridColumn: 2, gridRow: mark.row }"
+        />
+
+        <NuxtLink
+          v-for="session in roomSessions(room)"
+          :key="session.id"
+          class="min-w-0 block"
+          :style="{
+            gridColumn: 2,
+            gridRow: `${session.rowStart} / ${session.rowEnd}`,
+            paddingBottom: `${CARD_GAP}px`,
+          }"
+          :to="localePath(`/session/${session.id}`)"
+        >
+          <CpTrackSessionBlock
+            :difficulty="session.difficulty"
+            :end="session.end"
+            :speaker="session.speaker"
+            :start="session.start"
+            :title="session.title"
+          />
+        </NuxtLink>
+      </div>
+    </div>
+
+    <p
+      v-if="rooms.length === 0"
+      class="text-gray-400 py-8 text-center"
+    >
+      {{ t('noSession') }}
+    </p>
+  </div>
+</template>
+
+<i18n lang="yaml">
+  en:
+    noSession: 'No sessions on this day.'
+    difficulty:
+      Elementary: 'Elementary'
+      Intermediate: 'Intermediate'
+      Advanced: 'Advanced'
+      Professional: 'Professional'
+  zh:
+    noSession: '這天沒有議程。'
+    difficulty:
+      Elementary: '入門'
+      Intermediate: '中階'
+      Advanced: '進階'
+      Professional: '專業'
+</i18n>

--- a/app/components/feature/CpTrackSessionBlock.vue
+++ b/app/components/feature/CpTrackSessionBlock.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+defineProps<{
+  title: string
+  speaker: string
+  start: string
+  end: string
+  difficulty?: string
+}>()
+</script>
+
+<template>
+  <div class="text-white px-3 py-1.5 rounded-lg bg-primary-400 flex flex-col gap-1 h-full transition-shadow overflow-hidden hover:shadow-lg">
+    <!-- 時段過短時整體裁切；外層 flex-1 讓時間列固定在底部 -->
+    <div class="flex flex-1 flex-col gap-0.5 min-h-0 overflow-hidden">
+      <h4 class="text-sm leading-tight font-bold line-clamp-2">
+        {{ title }}
+      </h4>
+      <p
+        v-if="speaker"
+        class="text-xs opacity-90 line-clamp-1"
+      >
+        {{ speaker }}
+      </p>
+    </div>
+    <div class="flex flex-shrink-0 gap-2 items-center">
+      <time class="text-xs opacity-80">{{ start }}–{{ end }}</time>
+      <span
+        v-if="difficulty"
+        class="text-[10px] leading-none px-1.5 py-0.5 rounded bg-white/20"
+      >
+        {{ difficulty }}
+      </span>
+    </div>
+  </div>
+</template>

--- a/app/components/feature/CpTrackSessionPanel.vue
+++ b/app/components/feature/CpTrackSessionPanel.vue
@@ -78,6 +78,7 @@ onUnmounted(() => {
         </div>
 
         <CpSessionInfoCard
+          :ad="null"
           :description="sessionInfo.description"
           :room="sessionInfo.room"
           :speakers="sessionInfo.speakers"

--- a/app/components/feature/CpTrackSessionPanel.vue
+++ b/app/components/feature/CpTrackSessionPanel.vue
@@ -18,8 +18,8 @@ const localeKey = computed(() => (locale.value === 'zh' ? 'zh' : 'en'))
 const sessionInfo = computed(() => {
   const content = session[localeKey.value]
   const room = locale.value === 'zh'
-    ? (session.room?.['zh-hans'] || session.room?.en || '')
-    : (session.room?.en || session.room?.['zh-hans'] || '')
+    ? (session.room?.['zh-hant'] || session.room?.en || '')
+    : (session.room?.en || session.room?.['zh-hant'] || '')
 
   return {
     description: content.describe,

--- a/app/components/feature/CpTrackSessionPanel.vue
+++ b/app/components/feature/CpTrackSessionPanel.vue
@@ -61,7 +61,7 @@ onUnmounted(() => {
     role="dialog"
     @click.self="emit('close')"
   >
-    <div class="bg-white flex flex-row-reverse h-full w-120 right-0 top-0 fixed">
+    <div class="bg-white flex flex-row-reverse h-full max-w-120 w-full right-0 top-0 fixed">
       <div class="p-3 h-full w-full overflow-y-auto">
         <div class="z-content flex top-0 justify-end sticky">
           <button

--- a/app/components/feature/CpTrackSessionPanel.vue
+++ b/app/components/feature/CpTrackSessionPanel.vue
@@ -1,0 +1,98 @@
+<script setup lang="ts">
+import type { SessionSummary } from '#shared/types/session'
+import { useI18n } from '#imports'
+import CpSessionInfoCard from './CpSessionInfoCard.vue'
+
+const { session } = defineProps<{
+  session: SessionSummary
+}>()
+
+const emit = defineEmits<{
+  close: []
+}>()
+
+const { t, locale } = useI18n()
+
+const localeKey = computed(() => (locale.value === 'zh' ? 'zh' : 'en'))
+
+const sessionInfo = computed(() => {
+  const content = session[localeKey.value]
+  const room = locale.value === 'zh'
+    ? (session.room?.['zh-hans'] || session.room?.en || '')
+    : (session.room?.en || session.room?.['zh-hans'] || '')
+
+  return {
+    description: content.describe,
+    room,
+    speakers: session.speakers.map((speaker) => ({
+      id: speaker.id,
+      avatar: speaker.avatar ?? undefined,
+      bio: speaker[localeKey.value].bio,
+      name: speaker[localeKey.value].name,
+    })),
+    tags: session.tags,
+    time: `${session.start?.slice(11, 16) ?? ''} ~ ${session.end?.slice(11, 16) ?? ''}`,
+    title: content.title,
+  }
+})
+
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape') {
+    emit('close')
+  }
+}
+
+onMounted(() => {
+  document.body.style.overflow = 'hidden'
+  window.addEventListener('keydown', onKeydown)
+})
+
+onUnmounted(() => {
+  document.body.style.overflow = ''
+  window.removeEventListener('keydown', onKeydown)
+})
+</script>
+
+<template>
+  <div
+    :aria-label="sessionInfo.title"
+    aria-modal="true"
+    class="z-modal bg-black/50 inset-0 fixed"
+    role="dialog"
+    @click.self="emit('close')"
+  >
+    <div class="bg-white flex flex-row-reverse h-full w-120 right-0 top-0 fixed">
+      <div class="p-3 h-full w-full overflow-y-auto">
+        <div class="z-content flex top-0 justify-end sticky">
+          <button
+            :aria-label="t('close')"
+            class="text-gray-500 rounded-full flex h-8 w-8 transition-colors items-center justify-center hover:bg-gray-100"
+            type="button"
+            @click="emit('close')"
+          >
+            <Icon
+              class="h-4 w-4"
+              name="tabler:x"
+            />
+          </button>
+        </div>
+
+        <CpSessionInfoCard
+          :description="sessionInfo.description"
+          :room="sessionInfo.room"
+          :speakers="sessionInfo.speakers"
+          :tags="sessionInfo.tags"
+          :time="sessionInfo.time"
+          :title="sessionInfo.title"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<i18n lang="yaml">
+  en:
+    close: 'Close'
+  zh:
+    close: '關閉'
+</i18n>

--- a/app/composables/useSessionFilter.ts
+++ b/app/composables/useSessionFilter.ts
@@ -12,7 +12,7 @@ interface UseSessionFilterOptions {
 }
 
 function roomId(session: SessionSummary) {
-  return session.room?.en || session.room?.['zh-hans'] || ''
+  return session.room?.en || session.room?.['zh-hant'] || ''
 }
 
 export function useSessionFilter({ sessionsByDay, selectedDay, locale }: UseSessionFilterOptions) {
@@ -28,7 +28,7 @@ export function useSessionFilter({ sessionsByDay, selectedDay, locale }: UseSess
   })
 
   function roomLabel(session: SessionSummary) {
-    const { en = '', 'zh-hans': zh = '' } = session.room ?? {}
+    const { en = '', 'zh-hant': zh = '' } = session.room ?? {}
     return isZh.value ? zh || en : en || zh
   }
 

--- a/app/data/trackMeta.ts
+++ b/app/data/trackMeta.ts
@@ -1,0 +1,50 @@
+// 議程軌的補充資料。
+//
+// Pretalx 的 track 只有 name 與 description 兩個欄位，
+// 但議程軌詳細頁還需要「概要、社群連結、公告」等社群自訂內容。
+// 這些資料目前沒有上游來源，因此先在這裡以 track id 為索引手動維護，
+// 頁面在欄位缺漏時會優雅地隱藏對應區塊。
+
+export interface LocalizedText {
+  zh: string
+  en: string
+}
+
+export interface TrackLink {
+  /** 連結文字（雙語） */
+  label: LocalizedText
+  /** 連結網址 */
+  url: string
+}
+
+export interface TrackMeta {
+  /** 議程軌概要，顯示於標題下方的一行簡介 */
+  subtitle?: LocalizedText
+  /** 議程結束後活動等公告，顯示於描述上方的告示框 */
+  announcement?: LocalizedText
+  /** 社群連結，如官方網站、Facebook 社群 */
+  links?: TrackLink[]
+}
+
+// key 為 Pretalx track id。
+export const trackMeta: Record<number, TrackMeta> = {
+  // 範例（待填入真實資料）：
+  // 123: {
+  //   subtitle: {
+  //     zh: 'Java Virtual Machine 開發者在台灣的交流基地',
+  //     en: 'A hub for JVM developers in Taiwan',
+  //   },
+  //   announcement: {
+  //     zh: '議程結束後將舉辦 Open Space 討論，歡迎帶著你的技術問題一起交流！',
+  //     en: 'An Open Space discussion will be held after the sessions. Bring your technical questions!',
+  //   },
+  //   links: [
+  //     { label: { zh: '官方網站', en: 'Website' }, url: 'https://example.org' },
+  //     { label: { zh: 'Facebook 社群', en: 'Facebook' }, url: 'https://facebook.com/example' },
+  //   ],
+  // },
+}
+
+export function getTrackMeta(id: number): TrackMeta {
+  return trackMeta[id] ?? {}
+}

--- a/app/pages/session/[id].vue
+++ b/app/pages/session/[id].vue
@@ -28,8 +28,8 @@ const sessionInfo = computed(() => {
 
   const content = sessionDetail.value[localeKey.value]
   const room = locale.value === 'zh'
-    ? (sessionDetail.value.room?.['zh-hans'] || sessionDetail.value.room?.en || '')
-    : (sessionDetail.value.room?.en || sessionDetail.value.room?.['zh-hans'] || '')
+    ? (sessionDetail.value.room?.['zh-hant'] || sessionDetail.value.room?.en || '')
+    : (sessionDetail.value.room?.en || sessionDetail.value.room?.['zh-hant'] || '')
 
   return {
     coWrite: sessionDetail.value.co_write ?? undefined,

--- a/app/pages/track/[id].vue
+++ b/app/pages/track/[id].vue
@@ -142,12 +142,12 @@ useSeoMeta({
       <span>{{ announcement }}</span>
     </div>
 
-    <p
+    <div
       v-if="description"
-      class="text-gray-700 leading-relaxed whitespace-pre-line"
+      class="text-gray-700 leading-relaxed break-words"
     >
-      {{ description }}
-    </p>
+      <MDC :value="description" />
+    </div>
 
     <section
       v-if="selectedDay"

--- a/app/pages/track/[id].vue
+++ b/app/pages/track/[id].vue
@@ -17,12 +17,12 @@ const localeKey = computed(() => (locale.value === 'zh' ? 'zh' : 'en'))
 const meta = computed(() => getTrackMeta(Number(route.params.id)))
 
 const title = computed(() =>
-  data.value?.name[localeKey.value === 'zh' ? 'zh-hans' : 'en'] ||
+  data.value?.name[localeKey.value === 'zh' ? 'zh-hant' : 'en'] ||
   data.value?.name.en ||
   '')
 
 const description = computed(() =>
-  data.value?.description[localeKey.value === 'zh' ? 'zh-hans' : 'en'] ||
+  data.value?.description[localeKey.value === 'zh' ? 'zh-hant' : 'en'] ||
   data.value?.description.en ||
   '')
 
@@ -65,7 +65,7 @@ function closeSession() {
 }
 
 const dayRooms = computed(() => {
-  const key = localeKey.value === 'zh' ? 'zh-hans' : 'en'
+  const key = localeKey.value === 'zh' ? 'zh-hant' : 'en'
   const names = daySessions.value
     .map((session) => session.room?.[key] || session.room?.en)
     .filter((name): name is string => Boolean(name))
@@ -73,7 +73,7 @@ const dayRooms = computed(() => {
 })
 
 const allRooms = computed(() => {
-  const key = localeKey.value === 'zh' ? 'zh-hans' : 'en'
+  const key = localeKey.value === 'zh' ? 'zh-hant' : 'en'
   const names = Object.values(data.value?.sessions ?? {})
     .flat()
     .map((session) => session.room?.[key] || session.room?.en)

--- a/app/pages/track/[id].vue
+++ b/app/pages/track/[id].vue
@@ -1,0 +1,168 @@
+<script setup lang="ts">
+import type { SessionSummary, TrackDetail } from '#shared/types/session'
+import { useI18n } from 'vue-i18n'
+import CpTrackHeader from '~/components/feature/CpTrackHeader.vue'
+import CpTrackSchedule from '~/components/feature/CpTrackSchedule.vue'
+import { getTrackMeta } from '~/data/trackMeta'
+
+const { t, locale } = useI18n()
+const route = useRoute()
+const localePath = useLocalePath()
+
+const { data } = await useFetch<TrackDetail>(`/api/track/${route.params.id}`)
+
+const localeKey = computed(() => (locale.value === 'zh' ? 'zh' : 'en'))
+const meta = computed(() => getTrackMeta(Number(route.params.id)))
+
+const title = computed(() =>
+  data.value?.name[localeKey.value === 'zh' ? 'zh-hans' : 'en'] ||
+  data.value?.name.en ||
+  '')
+
+const description = computed(() =>
+  data.value?.description[localeKey.value === 'zh' ? 'zh-hans' : 'en'] ||
+  data.value?.description.en ||
+  '')
+
+const subtitle = computed(() => meta.value.subtitle?.[localeKey.value])
+const announcement = computed(() => meta.value.announcement?.[localeKey.value])
+const links = computed(() =>
+  (meta.value.links ?? []).map((link) => ({ label: link.label[localeKey.value], url: link.url })))
+
+const days = computed(() => Object.keys(data.value?.sessions ?? {}).sort())
+const count = computed(() =>
+  Object.values(data.value?.sessions ?? {}).reduce((sum, list) => sum + list.length, 0))
+
+const manualSelectedDay = ref<string | null>(null)
+const selectedDay = computed({
+  get: () => manualSelectedDay.value ?? days.value[0] ?? '',
+  set: (value) => void (manualSelectedDay.value = value),
+})
+
+const daySessions = computed<SessionSummary[]>(() => data.value?.sessions[selectedDay.value] ?? [])
+
+const dayIndex = computed(() => days.value.indexOf(selectedDay.value) + 1)
+
+const dayRooms = computed(() => {
+  const key = localeKey.value === 'zh' ? 'zh-hans' : 'en'
+  const names = daySessions.value
+    .map((session) => session.room?.[key] || session.room?.en)
+    .filter((name): name is string => Boolean(name))
+  return [...new Set(names)].sort()
+})
+
+const allRooms = computed(() => {
+  const key = localeKey.value === 'zh' ? 'zh-hans' : 'en'
+  const names = Object.values(data.value?.sessions ?? {})
+    .flat()
+    .map((session) => session.room?.[key] || session.room?.en)
+    .filter((name): name is string => Boolean(name))
+  return [...new Set(names)].sort()
+})
+
+function formatFullDate(day: string) {
+  if (!day) {
+    return ''
+  }
+  return new Intl.DateTimeFormat(locale.value === 'zh' ? 'zh-TW' : 'en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    timeZone: 'Asia/Taipei',
+  }).format(new Date(`${day}T00:00:00+08:00`))
+}
+
+useSeoMeta({
+  title: () => title.value,
+  description: () => subtitle.value || description.value,
+  ogTitle: () => title.value,
+  ogDescription: () => subtitle.value || description.value,
+  twitterTitle: () => title.value,
+  twitterDescription: () => subtitle.value || description.value,
+})
+</script>
+
+<template>
+  <article
+    v-if="data"
+    class="mx-auto flex flex-col gap-6 max-w-3xl"
+  >
+    <NuxtLink
+      class="text-sm text-gray-500 inline-flex gap-1.5 w-fit transition-colors items-center hover:text-primary-500"
+      :to="localePath('/track')"
+    >
+      <Icon
+        class="h-4 w-4"
+        name="tabler:arrow-left"
+      />
+      {{ t('back') }}
+    </NuxtLink>
+
+    <CpTrackHeader
+      v-model="selectedDay"
+      :count="count"
+      :days="days"
+      :links="links"
+      :rooms="allRooms"
+      :subtitle="subtitle"
+      :title="title"
+    />
+
+    <hr class="border-gray-200">
+
+    <div
+      v-if="announcement"
+      class="text-sm text-gray-700 px-4 py-3 border border-gray-200 rounded-xl bg-gray-50 flex gap-3 items-center"
+    >
+      <Icon
+        class="text-primary-400 flex-shrink-0 h-5 w-5"
+        name="tabler:speakerphone"
+      />
+      <span>{{ announcement }}</span>
+    </div>
+
+    <p
+      v-if="description"
+      class="text-gray-700 leading-relaxed whitespace-pre-line"
+    >
+      {{ description }}
+    </p>
+
+    <section
+      v-if="selectedDay"
+      class="flex flex-col gap-4"
+    >
+      <div>
+        <h2 class="text-2xl text-primary-700 font-bold">
+          {{ t('day', { n: dayIndex }) }}
+        </h2>
+        <p class="text-sm text-gray-500 mt-1">
+          {{ formatFullDate(selectedDay) }}
+          <template v-if="dayRooms.length">
+            · {{ dayRooms.join('、') }}
+          </template>
+        </p>
+      </div>
+
+      <CpTrackSchedule :sessions="daySessions" />
+    </section>
+  </article>
+
+  <p
+    v-else
+    class="text-gray-500 py-20 text-center"
+  >
+    {{ t('notFound') }}
+  </p>
+</template>
+
+<i18n lang="yaml">
+  en:
+    back: 'Back to tracks'
+    day: 'Day {n}'
+    notFound: 'Track not found.'
+  zh:
+    back: '返回議程軌列表'
+    day: 'Day {n}'
+    notFound: '找不到這個議程軌。'
+</i18n>

--- a/app/pages/track/[id].vue
+++ b/app/pages/track/[id].vue
@@ -3,10 +3,12 @@ import type { SessionSummary, TrackDetail } from '#shared/types/session'
 import { useI18n } from 'vue-i18n'
 import CpTrackHeader from '~/components/feature/CpTrackHeader.vue'
 import CpTrackSchedule from '~/components/feature/CpTrackSchedule.vue'
+import CpTrackSessionPanel from '~/components/feature/CpTrackSessionPanel.vue'
 import { getTrackMeta } from '~/data/trackMeta'
 
 const { t, locale } = useI18n()
 const route = useRoute()
+const router = useRouter()
 const localePath = useLocalePath()
 
 const { data } = await useFetch<TrackDetail>(`/api/track/${route.params.id}`)
@@ -35,13 +37,32 @@ const count = computed(() =>
 
 const manualSelectedDay = ref<string | null>(null)
 const selectedDay = computed({
-  get: () => manualSelectedDay.value ?? days.value[0] ?? '',
+  get: () => {
+    if (manualSelectedDay.value && days.value.includes(manualSelectedDay.value)) {
+      return manualSelectedDay.value
+    }
+    return days.value[0] ?? ''
+  },
   set: (value) => void (manualSelectedDay.value = value),
 })
 
 const daySessions = computed<SessionSummary[]>(() => data.value?.sessions[selectedDay.value] ?? [])
 
-const dayIndex = computed(() => days.value.indexOf(selectedDay.value) + 1)
+const dayIndex = computed(() => {
+  const idx = days.value.indexOf(selectedDay.value)
+  return idx >= 0 ? idx + 1 : 1
+})
+
+// 被展開的議程（由 query string ?session=<id> 控制），直接展開成側邊面板。
+const allSessions = computed(() => Object.values(data.value?.sessions ?? {}).flat())
+const selectedSession = computed(() =>
+  allSessions.value.find((session) => session.id === route.query.session) ?? null)
+
+function closeSession() {
+  const query = { ...route.query }
+  delete query.session
+  router.replace({ query })
+}
 
 const dayRooms = computed(() => {
   const key = localeKey.value === 'zh' ? 'zh-hans' : 'en'
@@ -139,13 +160,21 @@ useSeoMeta({
         <p class="text-sm text-gray-500 mt-1">
           {{ formatFullDate(selectedDay) }}
           <template v-if="dayRooms.length">
-            · {{ dayRooms.join('、') }}
+            · {{ dayRooms.join(t('separator')) }}
           </template>
         </p>
       </div>
 
       <CpTrackSchedule :sessions="daySessions" />
     </section>
+
+    <ClientOnly>
+      <CpTrackSessionPanel
+        v-if="selectedSession"
+        :session="selectedSession"
+        @close="closeSession"
+      />
+    </ClientOnly>
   </article>
 
   <p
@@ -161,8 +190,10 @@ useSeoMeta({
     back: 'Back to tracks'
     day: 'Day {n}'
     notFound: 'Track not found.'
+    separator: ', '
   zh:
     back: '返回議程軌列表'
-    day: 'Day {n}'
+    day: '第 {n} 天'
     notFound: '找不到這個議程軌。'
+    separator: '、'
 </i18n>

--- a/app/pages/track/index.vue
+++ b/app/pages/track/index.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import type { TrackSummary } from '#shared/types/session'
+import { useI18n } from 'vue-i18n'
+
+// 內部檢查用的議程軌索引頁，方便逐一檢視各議程軌詳細頁。
+const { t, locale } = useI18n()
+const localePath = useLocalePath()
+
+const { data } = await useFetch<TrackSummary[]>('/api/track')
+
+const localeKey = computed(() => (locale.value === 'zh' ? 'zh-hans' : 'en'))
+
+function trackName(track: TrackSummary) {
+  return track.name[localeKey.value] || track.name.en || `#${track.id}`
+}
+
+useSeoMeta({
+  title: () => t('title'),
+})
+</script>
+
+<template>
+  <div class="mx-auto flex flex-col gap-6 max-w-3xl">
+    <h1 class="text-3xl text-primary-700 font-bold">
+      {{ t('title') }}
+    </h1>
+
+    <ul class="flex flex-col gap-2">
+      <li
+        v-for="track in data ?? []"
+        :key="track.id"
+      >
+        <NuxtLink
+          class="px-4 py-3 border border-gray-200 rounded-xl flex gap-3 transition-colors items-center justify-between hover:border-primary-400 hover:bg-primary-50"
+          :to="localePath(`/track/${track.id}`)"
+        >
+          <span class="text-gray-800 font-medium">{{ trackName(track) }}</span>
+          <span class="text-sm text-gray-500 whitespace-nowrap">{{ t('count', { count: track.count }) }}</span>
+        </NuxtLink>
+      </li>
+    </ul>
+
+    <p
+      v-if="!data?.length"
+      class="text-gray-400 py-8 text-center"
+    >
+      {{ t('empty') }}
+    </p>
+  </div>
+</template>
+
+<i18n lang="yaml">
+  en:
+    title: 'Tracks'
+    count: '{count} sessions'
+    empty: 'No tracks yet.'
+  zh:
+    title: '議程軌'
+    count: '{count} 場議程'
+    empty: '尚無議程軌。'
+</i18n>

--- a/app/pages/track/index.vue
+++ b/app/pages/track/index.vue
@@ -8,7 +8,7 @@ const localePath = useLocalePath()
 
 const { data } = await useFetch<TrackSummary[]>('/api/track')
 
-const localeKey = computed(() => (locale.value === 'zh' ? 'zh-hans' : 'en'))
+const localeKey = computed(() => (locale.value === 'zh' ? 'zh-hant' : 'en'))
 
 function trackName(track: TrackSummary) {
   return track.name[localeKey.value] || track.name.en || `#${track.id}`

--- a/app/router.options.ts
+++ b/app/router.options.ts
@@ -1,6 +1,7 @@
 import type { RouterConfig } from '@nuxt/schema'
 
 const SESSION_PATH_RE = /^\/(?:[^/]+\/)?session(?:\/|$)/
+const TRACK_PATH_RE = /^\/(?:[^/]+\/)?track(?:\/|$)/
 
 export default {
   scrollBehavior(to, from, savedPosition) {
@@ -11,6 +12,11 @@ export default {
     const isSessionPath = (path: string) => SESSION_PATH_RE.test(path)
 
     if (isSessionPath(to.path) && isSessionPath(from.path)) {
+      return false
+    }
+
+    // 議程軌頁面只變更 query/hash（例如以 ?session= 展開議程面板）時，維持捲動位置。
+    if (TRACK_PATH_RE.test(to.path) && to.path === from.path) {
       return false
     }
 

--- a/server/api/session/[id]/index.get.ts
+++ b/server/api/session/[id]/index.get.ts
@@ -44,12 +44,12 @@ export default defineEventHandler(async (event) => {
     zh: {
       title: submission.title,
       describe: submission.abstract,
-      type: type.name['zh-hans'] || type.name.en,
+      type: type.name['zh-hant'] || type.name.en,
     },
     en: {
       title: answers.enTitle || submission.title,
       describe: answers.enDesc || submission.abstract,
-      type: type.name.en || type.name['zh-hans'],
+      type: type.name.en || type.name['zh-hant'],
     },
     tags: parseTags(submission.tags, data, parseDifficulty(answers.difficulty)),
     uri: `https://coscup.org/2026/session/${submission.code}`,

--- a/server/api/session/index.get.ts
+++ b/server/api/session/index.get.ts
@@ -1,58 +1,17 @@
 import type { Submission } from '#shared/types/pretalx'
 import type { SessionSummary } from '#shared/types/session'
 import pretalxData from '#server/utils/pretalx'
-import { parseAnswer, parseDifficulty, parseSlot, parseSpeaker, parseTags, parseTrack, parseType } from '#server/utils/pretalx/parser'
+import { buildSessionSummary, groupSessionsByDay } from '#server/utils/pretalx/sessions'
 
 export default defineEventHandler(async () => {
   const data = await pretalxData()
 
   const submissions = data.submissions?.arr || []
 
-  return submissions
+  const sessions = submissions
     .filter((submission: Submission) => submission.state === 'confirmed')
-    .map((submission: Submission) => {
-      if (!submission.slots[0]) {
-        return null
-      }
+    .map((submission: Submission) => buildSessionSummary(submission, data))
+    .filter((session): session is SessionSummary => session !== null)
 
-      const answers = parseAnswer(submission.answers, data)
-      const slot = parseSlot(submission.slots[0], data)
-      const speakers = parseSpeaker(submission.speakers, data)
-      const type = parseType(submission.submission_type, data)
-
-      if (!slot || !slot.start || !slot.end || !slot.room) {
-        return null
-      }
-
-      return {
-        id: submission.code,
-        room: slot.room.name,
-        start: slot.start,
-        end: slot.end,
-        language: answers.language,
-        track: parseTrack(submission.track, data),
-        speakers,
-        zh: {
-          title: submission.title,
-          describe: submission.abstract,
-          type: type.name['zh-hans'] || type.name.en,
-        },
-        en: {
-          title: answers.enTitle || submission.title,
-          describe: answers.enDesc || submission.abstract,
-          type: type.name.en || type.name['zh-hans'],
-        },
-        tags: parseTags(submission.tags, data, parseDifficulty(answers.difficulty)),
-        uri: `https://coscup.org/2026/session/${submission.code}`,
-      }
-    })
-    .filter((session): session is NonNullable<typeof session> => session !== null)
-    .reduce((acc, session) => {
-      const day = session.start.slice(0, 10)
-      if (!acc[day]) {
-        acc[day] = []
-      }
-      acc[day].push(session)
-      return acc
-    }, {} as Record<string, SessionSummary[]>)
+  return groupSessionsByDay(sessions)
 })

--- a/server/api/track/[id]/index.get.ts
+++ b/server/api/track/[id]/index.get.ts
@@ -27,7 +27,7 @@ export default defineEventHandler(async (event): Promise<TrackDetail> => {
   return {
     id: track.id,
     name: track.name,
-    description: track.description ?? { 'en': '', 'zh-hans': '' },
+    description: track.description ?? { 'en': '', 'zh-hant': '' },
     sessions: groupSessionsByDay(sessions),
   }
 })

--- a/server/api/track/[id]/index.get.ts
+++ b/server/api/track/[id]/index.get.ts
@@ -1,0 +1,33 @@
+import type { Submission } from '#shared/types/pretalx'
+import type { SessionSummary, TrackDetail } from '#shared/types/session'
+import pretalxData from '#server/utils/pretalx'
+import { buildSessionSummary, groupSessionsByDay } from '#server/utils/pretalx/sessions'
+
+export default defineEventHandler(async (event): Promise<TrackDetail> => {
+  const id = Number(getRouterParam(event, 'id'))
+
+  if (!Number.isInteger(id)) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid track id' })
+  }
+
+  const data = await pretalxData()
+  const track = data.tracks.map[id]
+
+  if (!track) {
+    throw createError({ statusCode: 404, statusMessage: 'Track not found' })
+  }
+
+  const submissions = data.submissions?.arr || []
+
+  const sessions = submissions
+    .filter((submission: Submission) => submission.state === 'confirmed' && submission.track === id)
+    .map((submission: Submission) => buildSessionSummary(submission, data))
+    .filter((session): session is SessionSummary => session !== null)
+
+  return {
+    id: track.id,
+    name: track.name,
+    description: track.description ?? { 'en': '', 'zh-hans': '' },
+    sessions: groupSessionsByDay(sessions),
+  }
+})

--- a/server/api/track/index.get.ts
+++ b/server/api/track/index.get.ts
@@ -1,0 +1,25 @@
+import type { Submission } from '#shared/types/pretalx'
+import type { SessionSummary, TrackSummary } from '#shared/types/session'
+import pretalxData from '#server/utils/pretalx'
+import { buildSessionSummary } from '#server/utils/pretalx/sessions'
+
+export default defineEventHandler(async (): Promise<TrackSummary[]> => {
+  const data = await pretalxData()
+
+  const submissions = data.submissions?.arr || []
+
+  const counts = new Map<number, number>()
+  submissions
+    .filter((submission: Submission) => submission.state === 'confirmed')
+    .map((submission: Submission) => buildSessionSummary(submission, data))
+    .filter((session): session is SessionSummary => session !== null)
+    .forEach((session) => {
+      if (session.track) {
+        counts.set(session.track.id, (counts.get(session.track.id) ?? 0) + 1)
+      }
+    })
+
+  return data.tracks.arr
+    .map((track) => ({ id: track.id, name: track.name, count: counts.get(track.id) ?? 0 }))
+    .sort((a, b) => b.count - a.count || a.id - b.id)
+})

--- a/server/utils/opass/pretalxToOpass.ts
+++ b/server/utils/opass/pretalxToOpass.ts
@@ -87,10 +87,10 @@ export function pretalxToOpass(pretalxData: PretalxResult) {
     return {
       id: type.id,
       zh: {
-        name: type.name['zh-hans'] || type.name.en,
+        name: type.name['zh-hant'] || type.name.en,
       },
       en: {
-        name: type.name.en || type.name['zh-hans'],
+        name: type.name.en || type.name['zh-hant'],
       },
     }
   })
@@ -109,10 +109,10 @@ export function pretalxToOpass(pretalxData: PretalxResult) {
       return {
         id: room.id,
         zh: {
-          name: room.name['zh-hans'] || room.name.en,
+          name: room.name['zh-hant'] || room.name.en,
         },
         en: {
-          name: room.name.en || room.name['zh-hans'],
+          name: room.name.en || room.name['zh-hant'],
         },
       }
     })

--- a/server/utils/pretalx/sessions.ts
+++ b/server/utils/pretalx/sessions.ts
@@ -1,0 +1,54 @@
+import type { PretalxResult, Submission } from '#shared/types/pretalx'
+import type { SessionSummary } from '#shared/types/session'
+import { parseAnswer, parseDifficulty, parseSlot, parseSpeaker, parseTags, parseTrack, parseType } from './parser'
+
+// 將單一 pretalx submission 轉換成 SessionSummary。
+// 若 submission 沒有有效的時段（slot/start/end/room），回傳 null。
+export function buildSessionSummary(submission: Submission, data: PretalxResult): SessionSummary | null {
+  if (!submission.slots[0]) {
+    return null
+  }
+
+  const answers = parseAnswer(submission.answers, data)
+  const slot = parseSlot(submission.slots[0], data)
+  const speakers = parseSpeaker(submission.speakers, data)
+  const type = parseType(submission.submission_type, data)
+
+  if (!slot || !slot.start || !slot.end || !slot.room) {
+    return null
+  }
+
+  return {
+    id: submission.code,
+    room: slot.room.name,
+    start: slot.start,
+    end: slot.end,
+    language: answers.language,
+    track: parseTrack(submission.track, data),
+    speakers,
+    zh: {
+      title: submission.title,
+      describe: submission.abstract,
+      type: type.name['zh-hans'] || type.name.en,
+    },
+    en: {
+      title: answers.enTitle || submission.title,
+      describe: answers.enDesc || submission.abstract,
+      type: type.name.en || type.name['zh-hans'],
+    },
+    tags: parseTags(submission.tags, data, parseDifficulty(answers.difficulty)),
+    uri: `https://coscup.org/2026/session/${submission.code}`,
+  }
+}
+
+// 依開始日期（YYYY-MM-DD）將 session 分組。
+export function groupSessionsByDay(sessions: SessionSummary[]): Record<string, SessionSummary[]> {
+  return sessions.reduce((acc, session) => {
+    const day = session.start!.slice(0, 10)
+    if (!acc[day]) {
+      acc[day] = []
+    }
+    acc[day].push(session)
+    return acc
+  }, {} as Record<string, SessionSummary[]>)
+}

--- a/server/utils/pretalx/sessions.ts
+++ b/server/utils/pretalx/sessions.ts
@@ -29,12 +29,12 @@ export function buildSessionSummary(submission: Submission, data: PretalxResult)
     zh: {
       title: submission.title,
       describe: submission.abstract,
-      type: type.name['zh-hans'] || type.name.en,
+      type: type.name['zh-hant'] || type.name.en,
     },
     en: {
       title: answers.enTitle || submission.title,
       describe: answers.enDesc || submission.abstract,
-      type: type.name.en || type.name['zh-hans'],
+      type: type.name.en || type.name['zh-hant'],
     },
     tags: parseTags(submission.tags, data, parseDifficulty(answers.difficulty)),
     uri: `https://coscup.org/2026/session/${submission.code}`,

--- a/shared/types/pretalx.ts
+++ b/shared/types/pretalx.ts
@@ -14,7 +14,7 @@ export const PretalxTableSchema = z.enum(PRETALX_TABLES)
 
 export const PretalxLocaleSchema = z.object({
   'en': z.string().optional().default(''),
-  'zh-hans': z.string().optional().default(''),
+  'zh-hant': z.string().optional().default(''),
 })
 
 export const SubmissionSchema = z.object({

--- a/shared/types/session.ts
+++ b/shared/types/session.ts
@@ -52,8 +52,25 @@ export const SessionDetailSchema = SessionSummarySchema.extend({
   record: z.null(),
 })
 
+export const TrackSummarySchema = z.object({
+  id: z.number(),
+  name: PretalxLocaleSchema,
+  // 該議程軌的場次數量。
+  count: z.number(),
+})
+
+export const TrackDetailSchema = z.object({
+  id: z.number(),
+  name: PretalxLocaleSchema,
+  description: PretalxLocaleSchema,
+  // 該議程軌的場次，依日期（YYYY-MM-DD）分組。
+  sessions: z.record(z.string(), z.array(SessionSummarySchema)),
+})
+
 export type SessionSpeaker = z.infer<typeof SessionSpeakerSchema>
 export type SessionDifficulty = z.infer<typeof SessionDifficultySchema>
 export type SessionTrack = z.infer<typeof SessionTrackSchema>
 export type SessionSummary = z.infer<typeof SessionSummarySchema>
 export type SessionDetail = z.infer<typeof SessionDetailSchema>
+export type TrackSummary = z.infer<typeof TrackSummarySchema>
+export type TrackDetail = z.infer<typeof TrackDetailSchema>


### PR DESCRIPTION
實作 #209：獨立的議程軌頁面。

> 本 PR 只負責**議程軌詳細頁**。美觀的議程軌列表頁由他人負責；這裡附帶的 `/track` 只是內部檢查用的索引頁。

## 內容

**議程軌詳細頁 `/track/[id]`**（依新設計）
- 標題、右上角「N 場議程」、概要副標
- 議程日數切換、教室、社群連結
- 公告 banner、議程軌描述
- 依時間比例排版的議程表：CSS grid 時間軸，整點實線＋半點虛線，卡片與刻度線共用同一組 grid 列而精準對齊

<img width="3248" height="2122" alt="CleanShot 2026-06-20 at 22 07 09@2x" src="https://github.com/user-attachments/assets/d50b6f51-dc5f-42dc-b654-36d53abe2f3a" />

<img width="3248" height="2122" alt="CleanShot 2026-06-20 at 22 06 45@2x" src="https://github.com/user-attachments/assets/eb749780-79d3-4c7a-bada-d34bfb55d5fc" />

<img width="3248" height="2122" alt="CleanShot 2026-06-20 at 22 06 42@2x" src="https://github.com/user-attachments/assets/1b286f72-de58-4292-a7f4-38bf6cb3ac78" />

**議程軌索引頁 `/track`**（內部檢查用）
- 列出所有議程軌與場次數，連到各詳細頁

<img width="3248" height="2122" alt="CleanShot 2026-06-20 at 22 06 57@2x" src="https://github.com/user-attachments/assets/2e562640-ef1d-4d41-96b6-a3c5fdc12cae" />

## 設計決定

- 設計系統交給 Riley 重新定義，這裡就繼續用 `primary` 來保證語意一致
- 再麻煩 @mirumodapon 提供社群資訊的 Google Spreadsheet，用來取代 `app/data/trackMeta.ts`。
- 議程軌列表頁現在是隨便設計的，考慮到 Riley 之後就會設計跳轉過去的頁面。

## 待辦（非本 PR 範圍）
- `app/data/trackMeta.ts` 目前只有範例結構，需填入各議程軌真實資料。
- 正式的議程軌列表頁（美觀版）由他人負責；屆時詳細頁「返回議程軌列表」連結指向 `/track`，可視情況調整。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added track browsing with a track list showing confirmed session counts.
  * Added track detail pages with localized, day-based filtering and a per-room timetable grid with time-aligned session blocks.
  * Added a session details modal with close controls and scroll locking.
  * Added a track header with localized subtitles/announcements, room locations, and external community links.
* **Improvements**
  * Improved in-track navigation scrolling to better preserve position when switching within the same track path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->