### PR TITLE
fix: 搜尋列沒有正常顯示

### DIFF
--- a/app/components/feature/CpSessionDaySelector.vue
+++ b/app/components/feature/CpSessionDaySelector.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 const props = defineProps<{ days: string[] }>()
 
-const selectedDay = defineModel<string>()
+const selectedDay = defineModel<string | null>({ required: true })
 
 function formatDayLabel(day: string) {
   return new Intl.DateTimeFormat('en-US', {

--- a/app/components/feature/CpSessionFilterBar.vue
+++ b/app/components/feature/CpSessionFilterBar.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { FilterOption } from '~/composables/useSessionFilter'
+import CpTextField from '~/components/shared/CpTextField.vue'
 import CpSessionFilterDropdown from './CpSessionFilterDropdown.vue'
 
 defineProps<{

--- a/app/vue.d.ts
+++ b/app/vue.d.ts
@@ -1,0 +1,14 @@
+import type { ImgHTMLAttributes } from 'vue'
+
+declare module 'vue' {
+  // NuxtImg 的部分 HTML 屬性無法正確透傳，比如 alt 屬性、@click 事件，
+  // 導致在啟用 strictTemplates 的情況下，typecheck 會失敗。
+  // 因此，這裡先給所有元件 extend ImgHTMLAttributes，避免報錯。
+  // 這也是 vue-tsc 上現在唯一比較簡單的 workaround。
+  //
+  // Error example:
+  //    error TS2353: Object literal may only specify known properties,
+  //    and 'alt' does not exist in type '{ ... } & VNodeProps & Allowed
+  //    ComponentProps & ComponentCusto...'.
+  interface ComponentCustomProps extends ImgHTMLAttributes {}
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -104,6 +104,18 @@ export default defineNuxtConfig({
 
   typescript: {
     typeCheck: true,
+    tsConfig: {
+      vueCompilerOptions: {
+        strictTemplates: true,
+        strictVModel: true,
+        strictCssModules: true,
+        checkUnknownProps: true,
+        checkUnknownEvents: true,
+        checkUnknownDirectives: true,
+        checkUnknownComponents: true,
+        target: 3.5,
+      },
+    },
   },
 
   modules: [


### PR DESCRIPTION
事故原因是因為在重構 Vue 元件的過程中，沒有注意到 `CpTextField` 沒有匯入到元件當中。為了杜絕這類問題的再次發生，我也啟用了比較嚴格的 Vue 類型檢查，並同時抓到了幾個 code smells。

| Before | After |
| ------ | ----- |
| <img width="2094" height="1806" alt="CleanShot 2026-06-21 at 11 40 03@2x" src="https://github.com/user-attachments/assets/95613647-f192-479a-ad21-2ca9248d9098" /> | <img width="2206" height="1488" alt="CleanShot 2026-06-21 at 11 39 16@2x" src="https://github.com/user-attachments/assets/2e7e6bdd-be30-4e59-8958-3b05f0d0e3b2" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed missing component import that could cause rendering errors.
  * Enhanced type safety and validation in component models and build configuration for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->