### PR TITLE
feat(opass): add tags section to opass.json

### DIFF
--- a/server/utils/opass/pretalxToOpass.ts
+++ b/server/utils/opass/pretalxToOpass.ts
@@ -1,5 +1,6 @@
 import type { OpassTag } from '#server/utils/opass/tags'
 import type { PretalxResult, Room, Speaker, Submission, SubmissionType } from '#shared/types/pretalx'
+import { sessionTags } from '#server/utils/opass/tags'
 import { parseAnswer, parseSlot } from '#server/utils/pretalx/parser'
 
 export function pretalxToOpass(pretalxData: PretalxResult) {

--- a/server/utils/opass/pretalxToOpass.ts
+++ b/server/utils/opass/pretalxToOpass.ts
@@ -1,10 +1,12 @@
+import type { OpassTag } from '#server/utils/opass/tags'
 import type { PretalxResult, Room, Speaker, Submission, SubmissionType } from '#shared/types/pretalx'
-import { parseAnswer, parseDifficulty, parseSlot, parseTags } from '#server/utils/pretalx/parser'
+import { parseAnswer, parseSlot } from '#server/utils/pretalx/parser'
 
 export function pretalxToOpass(pretalxData: PretalxResult) {
   const speakerIds: Set<Speaker['code']> = new Set()
   const roomIds: Set<Room['id']> = new Set()
   const typeIds: Set<SubmissionType['id']> = new Set()
+  const tagMap = new Map<string, OpassTag>()
 
   const sessions = pretalxData.submissions.arr
     .filter((submission: Submission) => submission.state === 'confirmed')
@@ -19,6 +21,9 @@ export function pretalxToOpass(pretalxData: PretalxResult) {
       if (slot?.room?.id) {
         roomIds.add(slot.room.id)
       }
+
+      const tags = sessionTags(answer.language, answer.difficulty)
+      tags.forEach((tag) => tagMap.set(tag.id, tag))
 
       return {
         id: submission.code,
@@ -36,7 +41,7 @@ export function pretalxToOpass(pretalxData: PretalxResult) {
           title: answer.enTitle || submission.title,
           describe: answer.enDesc || submission.abstract,
         },
-        tags: parseTags(submission.tags, pretalxData, parseDifficulty(answer.difficulty)),
+        tags: tags.map((tag) => tag.id),
         uri: `https://coscup.org/2026/session/${submission.code}`,
         co_write: null,
         qa: null,
@@ -112,5 +117,5 @@ export function pretalxToOpass(pretalxData: PretalxResult) {
     })
     .filter((x): x is NonNullable<typeof x> => x !== null)
 
-  return { sessions, speakers, session_types: types, rooms }
+  return { sessions, speakers, session_types: types, rooms, tags: [...tagMap.values()] }
 }

--- a/server/utils/opass/tags.ts
+++ b/server/utils/opass/tags.ts
@@ -1,0 +1,65 @@
+import { parseDifficulty } from '#server/utils/pretalx/parser'
+
+// OPass app 的 tag 分類沿用 2025：議程以 slug id 參照 tag，
+// 而頂層 `tags` 字典提供每個 slug 的多語名稱。分類僅含語言與難度，
+// 不含 pretalx 自訂標籤。
+
+export interface OpassTag {
+  id: string
+  zh: { name: string }
+  en: { name: string }
+}
+
+// 投稿語言原始字串 → 通用語言鍵（沿用 2025）。
+const LANGUAGE_GENERALIZE_MAP: Record<string, string> = {
+  中文: 'zh-tw',
+  漢語: 'zh-tw',
+  Chinese: 'zh-tw',
+  Mandarin: 'zh-tw',
+  中国語: 'zh-tw',
+  英文: 'en',
+  English: 'en',
+  英語: 'en',
+  Japanese: 'ja-JP',
+  日本語: 'ja-JP',
+  台語: 'taiwanese',
+  Taiwanese: 'taiwanese',
+  其他: 'others',
+  Others: 'others',
+  その他: 'others',
+}
+
+// 各通用鍵（語言 + 難度）的多語顯示名稱（沿用 2025 tagTranslations）。
+const TAG_NAMES: Record<string, { zh: string, en: string }> = {
+  'zh-tw': { zh: '漢語', en: 'Mandarin' },
+  'en': { zh: '英語', en: 'English' },
+  'ja-JP': { zh: '日本語', en: '日本語' },
+  'taiwanese': { zh: '台語', en: '台語' },
+  'others': { zh: '其他', en: '其他' },
+  'Elementary': { zh: '入門', en: 'Elementary' },
+  'Intermediate': { zh: '中階', en: 'Intermediate' },
+  'Advanced': { zh: '進階', en: 'Advanced' },
+  'Professional': { zh: '專業', en: 'Professional' },
+}
+
+function buildTag(id: string, key: string): OpassTag {
+  const name = TAG_NAMES[key]!
+  return { id, zh: { name: name.zh }, en: { name: name.en } }
+}
+
+// 由語言與難度算出議程的 tag 字典項目（含 slug id 與多語名稱）。
+export function sessionTags(language: string | undefined, difficultyRaw: string | undefined): OpassTag[] {
+  const tags: OpassTag[] = []
+
+  const lang = language ? LANGUAGE_GENERALIZE_MAP[language] : undefined
+  if (lang) {
+    tags.push(buildTag(`language_${lang.toLowerCase().replace(/-/g, '')}`, lang))
+  }
+
+  const diff = parseDifficulty(difficultyRaw)
+  if (diff) {
+    tags.push(buildTag(`difficulty_${diff.toLowerCase()}`, diff))
+  }
+
+  return tags
+}


### PR DESCRIPTION
Closes #202。

## 摘要

PR #174 已為每場議程加上 tags，但漏了 OPass 期望的頂層 `tags` 區塊。本 PR 補上，沿用 COSCUP 2025 的 OPass 匯出格式：

- 每場議程的 `tags` 改為參照 **slug id**（`language_zhtw`、`difficulty_intermediate`），而非名稱字串。
- 新增頂層 `tags` 字典，將每個 slug 對應到多語 `zh`/`en` 名稱——與 `session_types`/`rooms` 結構一致。
- 分類僅含**語言與難度**（與 2025 相同），不含 pretalx 自訂標籤。

範圍**僅限 opass.json**——`/api/session` 端點未更動，網站自身的 tag 顯示不受影響。

## 輸出範例

```json
"tags": [
  { "id": "language_others",         "zh": { "name": "其他" }, "en": { "name": "其他" } },
  { "id": "difficulty_intermediate", "zh": { "name": "中階" }, "en": { "name": "Intermediate" } }
]
```

議程參照：`"tags": ["language_zhtw", "difficulty_intermediate"]`

## 實作

- 新增 `server/utils/opass/tags.ts`——語言正規化表 + slug/名稱對照表（沿用 2025），並重用既有的 `parseDifficulty`。
- `pretalxToOpass.ts`——為每場議程建立 slug tags，並彙整成頂層 `tags` 區塊。

## 測試

`pnpm lint` 與 `pnpm typecheck` 皆通過。透過 `pnpm dev` → `GET /api/opass.json` 對 Pretalx API 實測：341 場已確認議程皆帶 slug tags，頂層區塊含預期的語言/難度項目。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session tags are now generated more consistently, including language and difficulty labels.
  * Exported session data now includes a top-level tags list, making tag information available across the app and downstream integrations.
  * Tag names are now shown in both Chinese and English for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->