### PR TITLE
pretalx 資料 2026

### DIFF
--- a/server/utils/pretalx/parser.ts
+++ b/server/utils/pretalx/parser.ts
@@ -79,12 +79,7 @@ export function parseSlot(slotId: Slot['id'], pretalxData: PretalxResult): Parse
   }
 
   const roomId = slot.room
-
-  if (!roomId) {
-    throw createError(`Room not found for slot: ${slotId}`)
-  }
-
-  const room = roomMap[roomId]
+  const room = roomId ? roomMap[roomId] : undefined
 
   return { ...slot, room }
 }

--- a/shared/types/pretalx.ts
+++ b/shared/types/pretalx.ts
@@ -79,8 +79,8 @@ export const SlotSchema = z.object({
   start: z.string().nullable().transform((value) => value),
   end: z.string().nullable().transform((value) => value),
   duration: z.number(),
-  description: z.string().nullable().transform((value) => value),
-  submission: SubmissionSchema.shape.code,
+  description: PretalxLocaleSchema.nullable(),
+  submission: SubmissionSchema.shape.code.nullable(),
   schedule: z.number(),
 })
 


### PR DESCRIPTION
這個 pr 是在處理 2026 資料時，有些資料層面上的問題

## 摘要

- 修正 `SlotSchema`，使 `submission` 允許 `null`（對應無議程的 break session），`description` 改為接受 `PretalxLocaleSchema` 物件（原本錯誤定義為 `string`）
- 移除 slot 無對應 room 時直接拋出錯誤的邏輯，改回傳 `undefined`，讓沒有場地的 slot 能正常處理

## 變更內容

| 檔案 | 變更 |
|------|------|
| `shared/types/pretalx.ts` | `SlotSchema.description`: `z.string().nullable()` → `PretalxLocaleSchema.nullable()`<br>`SlotSchema.submission`: `z.string()` → `z.string().nullable()` |
| `server/utils/pretalx/parser.ts` | `parseSlot`：移除 room 不存在時的 `throw createError(...)`，改為回傳 `undefined` |

## 根本原因

Pretalx API 回傳的 slot `description` 是多語系物件（`{ en: "...", "zh-hans": "..." }`），`submission` 在無關聯議程時回傳 `null`。原本的 schema 無法接受這些合法的 API 回應，導致 Zod 在 runtime 驗證失敗。
