### PR TITLE
fix: persist selected session day in URL

### DIFF
--- a/app/components/feature/CpSessionList.vue
+++ b/app/components/feature/CpSessionList.vue
@@ -11,9 +11,14 @@ const { sessions: _sessions, preview = false } = defineProps<{
 }>()
 
 const { locale } = useI18n()
+const route = useRoute()
 const localePath = useLocalePath()
 const { isFavorite, toggleFavorite } = useFavorites()
 const favoriteLabel = useFavoriteLabel()
+
+function sessionPath(id: string) {
+  return localePath({ path: `/session/${id}`, query: route.query })
+}
 
 const sessions = computed(() => {
   if (!_sessions) {
@@ -62,7 +67,7 @@ const times = computed(() => Object.keys(sessions.value).sort())
           :start="session.start"
           :tags="session.tags"
           :title="session.title"
-          :to="localePath(`/session/${session.id}`)"
+          :to="sessionPath(session.id)"
           @toggle-favorite="toggleFavorite(session.id)"
         />
       </div>

--- a/app/components/feature/CpSessionTable.vue
+++ b/app/components/feature/CpSessionTable.vue
@@ -19,11 +19,16 @@ const { sessions: _sessions, day, timeRange, interval, rowHeight, columnWidth, p
 
 const { locale } = useI18n()
 const { time } = useRealtime()
+const route = useRoute()
 const localePath = useLocalePath()
 const { isFavorite, toggleFavorite } = useFavorites()
 const favoriteLabel = useFavoriteLabel()
 
 const { containerRef, isDragging } = useDragScroll({ scrollTarget: 'window' })
+
+function sessionPath(id: string) {
+  return localePath({ path: `/session/${id}`, query: route.query })
+}
 
 function parseMinutes(isoStr: string) {
   const match = isoStr.match(/T(\d{2}):(\d{2})/)
@@ -216,7 +221,7 @@ const showRealtimeLine = computed(() => {
       }"
       :tags="session.tags"
       :title="session.title"
-      :to="localePath(`/session/${session.id}`)"
+      :to="sessionPath(session.id)"
       @toggle-favorite="toggleFavorite(session.id)"
     />
 

--- a/app/pages/session.vue
+++ b/app/pages/session.vue
@@ -14,14 +14,17 @@ import { decodeFavorites, provideFavorites } from '~/composables/useFavorites'
 import { useSessionFilter } from '~/composables/useSessionFilter'
 
 const { locale, t } = useI18n()
-
-const { data } = await useFetch('/api/session')
-
-const { isFavorite, setFavorites, favorites } = provideFavorites()
 const route = useRoute()
 const router = useRouter()
 
+const { data } = await useFetch('/api/session')
+const { isFavorite, setFavorites, favorites } = provideFavorites()
+
 const days = computed(() => Object.keys(data?.value ?? {}).sort())
+const queryDay = computed(() => {
+  const day = route.query.day
+  return typeof day === 'string' && days.value.includes(day) ? day : null
+})
 
 // A `?filter=` link carries someone else's favorites, to preview and import.
 const hasShareLink = computed(() => String(route.query.filter ?? '').length > 0)
@@ -47,8 +50,30 @@ const firstSharedDay = computed(() => {
 
 const manualSelectedDay = ref<string | null>(null)
 const selectedDay = computed({
-  get: () => manualSelectedDay.value ?? firstSharedDay.value ?? days.value[0] ?? null,
-  set: (value) => void (manualSelectedDay.value = value),
+  get: () => queryDay.value ?? firstSharedDay.value ?? days.value[0] ?? null,
+  set: (value) => {
+    const nextQuery = { ...route.query }
+
+    if (value && days.value.includes(value)) {
+      nextQuery.day = value
+    } else {
+      delete nextQuery.day
+    }
+
+    if (nextQuery.day === route.query.day) {
+      return
+    }
+
+    void router.replace({ query: nextQuery })
+  },
+})
+
+watchEffect(() => {
+  if (route.query.day && !queryDay.value) {
+    const nextQuery = { ...route.query }
+    delete nextQuery.day
+    void router.replace({ query: nextQuery })
+  }
 })
 
 const {

--- a/app/pages/session.vue
+++ b/app/pages/session.vue
@@ -48,7 +48,6 @@ const firstSharedDay = computed(() => {
   return days.value.find((day) => (data?.value?.[day] ?? []).some((s) => shared.has(s.id))) ?? null
 })
 
-const manualSelectedDay = ref<string | null>(null)
 const selectedDay = computed({
   get: () => queryDay.value ?? firstSharedDay.value ?? days.value[0] ?? null,
   set: (value) => {
@@ -119,12 +118,17 @@ const emptyVariant = computed<'filter' | 'favorite' | 'shared'>(() => {
 })
 
 function clearShare() {
+  const query = { ...route.query }
+  const day = selectedDay.value
+
   // Pin the current day before the share query disappears; otherwise selectedDay
   // falls back to days[0], which may hold none of the imported sessions.
-  manualSelectedDay.value = selectedDay.value
-  const query = { ...route.query }
+  if (day && days.value.includes(day)) {
+    query.day = day
+  }
+
   delete query.filter
-  router.replace({ query })
+  void router.replace({ query })
 }
 
 function importShared() {

--- a/app/pages/session/[id].vue
+++ b/app/pages/session/[id].vue
@@ -57,7 +57,7 @@ useSeoMeta({
 })
 
 function close() {
-  router.push(localePath('/session'))
+  router.push(localePath({ path: '/session', query: route.query }))
 }
 
 function pickWeightedAd(ads: Ad[]) {


### PR DESCRIPTION
Close #226

## Summary

讓議程頁的日期可以透過 URL query 保存，避免切換語系後重新掛載 session 組件，導致日期狀態丟失。

## Changes

- 將議程頁的 selectedDay 從本地 state 改為由 route.query.day 驅動。
- 切換日期時使用 router.replace 更新 day query，避免新增瀏覽器歷史紀錄。
- 議程列表與議程表格中的詳情連結會帶上目前 query。
- 關閉議程詳情頁時會返回保留 query 的 /session 頁。

## Impact

- 影響範圍限於議程頁、議程列表、議程表格與議程詳情關閉行為。
- 無效或非單一字串的 day query 會 fallback 到第一個可用日期。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session day selection is now URL-driven and reflected in the address bar for easier sharing and returning to the same view.
  * Session navigation preserves your current filters and other query parameters.

* **Bug Fixes**
  * Closing a session now returns to the session list while keeping existing query parameters.
  * Invalid or outdated day selections are automatically removed from the URL.
  * Clearing share state now keeps the currently selected day in the URL before updating filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->