### PR TITLE
fix: add sponsor footer to session table layout

### DIFF
--- a/app/layouts/session-table.vue
+++ b/app/layouts/session-table.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import CpFooter from '~/components/shared/CpFooter.vue'
 import CpNavbar from '~/components/shared/CpNavbar.vue'
+import CpSponsorFooter from '~/components/shared/CpSponsorFooter.vue'
 
 function updateViewportWidth() {
   document.documentElement.style.setProperty('--viewport-width', `${document.documentElement.clientWidth}px`)
@@ -24,6 +25,7 @@ onUnmounted(() => {
       <slot />
     </main>
 
+    <CpSponsorFooter class="w-[var(--viewport-width,100vw)] left-0 sticky" />
     <CpFooter class="w-[var(--viewport-width,100vw)] left-0 sticky" />
   </div>
 </template>


### PR DESCRIPTION
Fix #233 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a sponsor footer to the session table layout.
  * The sponsor footer now appears above the existing footer and matches the page width styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->