### PR TITLE
fix: order session rooms

### DIFF
--- a/app/components/feature/CpSessionTable.vue
+++ b/app/components/feature/CpSessionTable.vue
@@ -43,6 +43,28 @@ function toRow(minutes: number) {
   return Math.round((minutes - timeStart.value) / interval) + 2
 }
 
+function roomSortRank(room: string) {
+  if (room === 'RB105') {
+    // Put the room with an opening first
+    return 0
+  }
+  if (room.startsWith('RB')) {
+    return 1
+  }
+  if (room.startsWith('AU')) {
+    return 2
+  }
+  if (room.startsWith('TR')) {
+    return 3
+  }
+  return 4
+}
+
+function compareRooms(a: string, b: string) {
+  const rankDiff = roomSortRank(a) - roomSortRank(b)
+  return rankDiff || a.localeCompare(b)
+}
+
 const rooms = computed(() => {
   if (!_sessions) {
     return []
@@ -52,7 +74,7 @@ const rooms = computed(() => {
     .map((session) => session.room?.en)
     .filter((value) => value !== undefined)
 
-  return [...new Set(rooms)].sort() satisfies string[]
+  return [...new Set(rooms)].sort(compareRooms) satisfies string[]
 })
 
 const timeLabels = computed(() => {


### PR DESCRIPTION
Fix #232 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Room lists are now shown in a more intuitive priority order, with key rooms appearing first.

* **Bug Fixes**
  * Improved room sorting so entries no longer rely on simple alphabetical order.
  * Duplicate rooms are still removed as before, while the display order is now more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->