### PR TITLE
feat: add track (議程軌) row pinning

### DIFF
--- a/app/components/feature/CpSessionTrackTable.vue
+++ b/app/components/feature/CpSessionTrackTable.vue
@@ -131,11 +131,16 @@ const tracks = computed(() => {
     })
 })
 
+// Default main-track key, derived event-wide so the first-visit pin doesn't depend on which day loaded.
+const defaultMainKey = computed(() => {
+  const main = (_sessions ?? []).find((session) => isMainTrack(session.track?.name))
+  return main?.track?.id != null ? String(main.track.id) : null
+})
+
 // On first visit, pin the main track by default.
-watch(tracks, () => {
-  if (pinnedKeys.value === null) {
-    const main = tracks.value.find((track) => track.isMain)
-    pinnedKeys.value = main ? [main.key] : []
+watch(defaultMainKey, (key) => {
+  if (pinnedKeys.value === null && key != null) {
+    pinnedKeys.value = [key]
   }
 }, { immediate: true })
 

--- a/app/components/feature/CpSessionTrackTable.vue
+++ b/app/components/feature/CpSessionTrackTable.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { SessionSummary, SessionTrack } from '#shared/types/session'
+import { StorageSerializers, useLocalStorage } from '@vueuse/core'
 import { useI18n } from 'vue-i18n'
 import { useDragScroll } from '~/composables/useDragScroll'
 import { useRealtime } from '~/composables/useRealtime'
@@ -79,8 +80,28 @@ const daySessions = computed(() =>
 // Rows are tracks. Track-less sessions collapse into one fallback bucket so nothing disappears.
 const NO_TRACK = '__none__'
 
+// Match by name (either locale) since Pretalx track ids aren't stable across events.
+const MAIN_TRACK_NAMES = ['主議程', 'Main Session Track']
+function isMainTrack(name?: SessionTrack['name']) {
+  return MAIN_TRACK_NAMES.includes(name?.['zh-hans'] ?? '') || MAIN_TRACK_NAMES.includes(name?.en ?? '')
+}
+
+// null = never visited (pin main by default); [] = user unpinned everything (respect it).
+// Explicit JSON serializer: a null default otherwise picks the String()-based `any` serializer.
+const pinnedKeys = useLocalStorage<string[] | null>('coscup-pinned-tracks', null, {
+  serializer: StorageSerializers.object,
+})
+const isPinned = (key: string) => (pinnedKeys.value ?? []).includes(key)
+
+function togglePin(key: string) {
+  const current = pinnedKeys.value ?? []
+  pinnedKeys.value = current.includes(key)
+    ? current.filter((k) => k !== key)
+    : [...current, key]
+}
+
 const tracks = computed(() => {
-  const byKey = new Map<string, { key: string, order: number, name: string, room: string }>()
+  const byKey = new Map<string, { key: string, order: number, name: string, room: string, isMain: boolean }>()
   for (const session of daySessions.value) {
     const id = session.track?.id
     const key = id != null ? String(id) : NO_TRACK
@@ -90,13 +111,33 @@ const tracks = computed(() => {
         order: id ?? Number.POSITIVE_INFINITY,
         name: session.track ? localeName(session.track.name) : t('other'),
         room: localeName(session.room),
+        isMain: isMainTrack(session.track?.name),
       })
     }
   }
+  // Color by stable track-id order so a track keeps its color regardless of pin state. Pinned
+  // group is ordered by pin order (newest last); unpinned keep id order (Array.sort is stable).
+  const pinOrder = new Map((pinnedKeys.value ?? []).map((key, index) => [key, index]))
   return [...byKey.values()]
     .sort((a, b) => a.order - b.order)
     .map((track, index) => ({ ...track, color: TRACK_COLORS[index % TRACK_COLORS.length]! }))
+    .sort((a, b) => {
+      const ai = pinOrder.get(a.key)
+      const bi = pinOrder.get(b.key)
+      if (ai != null && bi != null) {
+        return ai - bi
+      }
+      return (ai != null ? 0 : 1) - (bi != null ? 0 : 1)
+    })
 })
+
+// On first visit, pin the main track by default.
+watch(tracks, () => {
+  if (pinnedKeys.value === null) {
+    const main = tracks.value.find((track) => track.isMain)
+    pinnedKeys.value = main ? [main.key] : []
+  }
+}, { immediate: true })
 
 const trackIndex = computed(() => new Map(tracks.value.map((track, index) => [track.key, index])))
 
@@ -252,36 +293,49 @@ const HEADER_HEIGHT = 47
     <div
       v-for="(track, i) in tracks"
       :key="track.key"
-      class="border-b border-r border-b-[rgba(26,26,26,0.06)] border-r-[#bedbff] bg-white flex gap-3 cursor-default items-center left-0 sticky z-dropdown"
+      class="border-b border-r border-b-[rgba(26,26,26,0.06)] flex gap-3 cursor-default items-center left-0 sticky z-dropdown"
+      :class="isPinned(track.key)
+        ? 'border-r-[#bedbff] bg-[#eff6ff] shadow-[inset_4px_0px_0px_0px_#3b82f6]'
+        : 'border-r-[rgba(26,26,26,0.12)] bg-white'"
       :style="{ 'grid-row': i + 2, 'grid-column': 1, 'padding': '12px 17px 12px 16px' }"
       @pointerdown.stop
     >
       <div class="flex flex-1 flex-col min-w-0">
         <div class="flex gap-1.5 items-center">
           <span
-            class="text-[14px] text-[#1a1a1a] leading-[17.5px] font-semibold whitespace-nowrap truncate"
+            class="text-[14px] leading-[17.5px] font-semibold whitespace-nowrap truncate"
+            :class="isPinned(track.key) ? 'text-[#1447e6]' : 'text-[#1a1a1a]'"
           >{{ track.name }}</span>
         </div>
         <div
           v-if="track.room"
           class="pt-1 flex gap-0.5 items-center"
+          :class="isPinned(track.key) ? 'text-[#2b7fff]' : 'text-[#737373]'"
         >
           <Icon
-            class="text-[12px] text-gray-500 shrink-0"
+            class="text-[12px] shrink-0"
             name="tabler:map-pin"
           />
           <span
-            class="text-[12px] text-gray-500 leading-[16px] font-mono whitespace-nowrap"
+            class="text-[12px] leading-[16px] font-mono whitespace-nowrap"
           >{{ track.room }}</span>
         </div>
       </div>
       <div class="flex gap-1 items-center">
-        <span class="p-1.5 rounded-[4px] flex items-center">
+        <button
+          :aria-label="isPinned(track.key) ? t('unpinTrack') : t('pinTrack')"
+          :aria-pressed="isPinned(track.key)"
+          class="p-1.5 rounded-[4px] flex cursor-pointer items-center"
+          :class="isPinned(track.key) ? 'bg-[#dbeafe] text-[#1447e6]' : 'text-[#99a1af]'"
+          :title="isPinned(track.key) ? t('unpinTrack') : t('pinTrack')"
+          type="button"
+          @click="togglePin(track.key)"
+        >
           <Icon
-            class="text-[14px] text-[#99a1af]"
-            name="tabler:pin"
+            class="text-[14px]"
+            :name="isPinned(track.key) ? 'tabler:pin-filled' : 'tabler:pin'"
           />
-        </span>
+        </button>
         <span class="p-1 rounded-[4px] flex items-center">
           <Icon
             class="text-[16px] text-[#99a1af]"
@@ -374,7 +428,11 @@ const HEADER_HEIGHT = 47
   en:
     other: 'Other'
     trackColumn: 'Track'
+    pinTrack: 'Pin track'
+    unpinTrack: 'Unpin track'
   zh:
     other: '其他'
     trackColumn: '議程軌'
+    pinTrack: '釘選議程軌'
+    unpinTrack: '取消釘選'
 </i18n>


### PR DESCRIPTION
依 Figma 新設計為桌面版「議程軌（社群）模式」議程表加入議程軌釘選（pin）功能，並預設釘選主議程。此為 #238 的後續，基底為 `session-track-mode` 分支。

## 變更內容
- 議程軌欄的釘選圖示改為可互動的切換按鈕（取代原本的靜態圖示），點擊即釘選／取消釘選該議程軌。
- 預設釘選「主議程」（Main Session Track）；以議程軌名稱比對（同時支援中英文名稱），不綁定會變動的 Pretalx track id。
- 釘選的議程軌移至列表頂端；釘選群組依「釘選順序」排列，後釘選者排在最後。
- 每個議程軌的顏色依 track id 順序固定，不受釘選重新排序影響。
- 釘選狀態以 `localStorage` 保存並跨重新載入；區分「從未造訪」（預設釘選主議程）與「使用者取消全部釘選」（保留空清單）。
- 釘選列樣式依 Figma：藍色左側強調條（4px `#3b82f6`）、blue-50 底色、藍色軌名／教室代碼、填色釘選按鈕；未釘選列維持預設中性樣式。
- 釘選按鈕 hover 顯示 pointer 游標。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-track pinning in the session track table, letting users keep important tracks at the top.
  * Track pin state is now saved between visits, so pinned tracks persist across sessions.
  * The main session track is automatically pinned on first visit.

* **UI Improvements**
  * Pinned tracks now have clearer visual emphasis.
  * The pin control is now interactive, with updated labels for better accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->