### PR TITLE
fix: 修正 staff 頁面未顯示資料

### DIFF
--- a/app/pages/staff.vue
+++ b/app/pages/staff.vue
@@ -73,6 +73,7 @@ zh:
     finance: 財務組
     service: 場務組
     production: 製播組
+    UCA: UCA
 en:
   noStaff: The staff information has not been announced yet.
   meta:
@@ -91,4 +92,5 @@ en:
     finance: Finance
     service: Service
     production: Production
+    UCA: UCA
 </i18n>

--- a/server/api/sheets/[sheet].get.ts
+++ b/server/api/sheets/[sheet].get.ts
@@ -16,7 +16,7 @@ export default defineCachedEventHandler(
     const { sheet } = await getValidatedRouterParams(event, requestSchema.parse)
     const name = SHEET_NAMES[sheet]
 
-    const url = `https://docs.google.com/spreadsheets/d/${googleSheetId}/gviz/tq?tqx=out:csv&sheet=${encodeURIComponent(name)}`
+    const url = `https://docs.google.com/spreadsheets/d/${googleSheetId}/gviz/tq?tqx=out:csv&sheet=${encodeURIComponent(name)}&headers=1`
     const csv = await $fetch<string>(url, { responseType: 'text' })
     const records = parse(csv, { columns: true, skip_empty_lines: true })
     return records

--- a/shared/types/staff.ts
+++ b/shared/types/staff.ts
@@ -1,10 +1,10 @@
 import { z } from 'zod'
 
-export const STAFF_GROUP_NAMES = ['總召組', '行政組', '議程組', '贊助組', '交流組', '公關組', '資訊組', '設計組', '紀錄組', '財務組', '場務組', '製播組'] as const
+export const STAFF_GROUP_NAMES = ['總召組', '行政組', '議程組', '贊助組', '交流組', '公關組', '資訊組', '設計組', '紀錄組', '財務組', '場務組', '製播組', 'UCA'] as const
 export const StaffGroupNameSchema = z.enum(STAFF_GROUP_NAMES)
 export type StaffGroupName = z.infer<typeof StaffGroupNameSchema>
 
-export const STAFF_GROUP_KEYS = ['coordinator', 'secretary', 'program', 'sponsorship', 'engagement', 'pr', 'it', 'design', 'documentary', 'finance', 'service', 'production'] as const
+export const STAFF_GROUP_KEYS = ['coordinator', 'secretary', 'program', 'sponsorship', 'engagement', 'pr', 'it', 'design', 'documentary', 'finance', 'service', 'production', 'UCA'] as const
 export const StaffGroupKeySchema = z.enum(STAFF_GROUP_KEYS)
 export type StaffGroupKey = z.infer<typeof StaffGroupKeySchema>
 
@@ -21,6 +21,7 @@ export const staffGroupKeyByName = {
   財務組: 'finance',
   場務組: 'service',
   製播組: 'production',
+  UCA: 'UCA',
 } as const satisfies Record<StaffGroupName, StaffGroupKey>
 
 export const StaffRowSchema = z.object({


### PR DESCRIPTION
## Summary

修正 staff 頁面沒有正確顯示工作人員資料的問題。主要原因包含 Google Sheets CSV 匯出時未明確指定 header row，導致資料解析結果不符合預期，以及 staff 分組型別尚未包含 UCA 分組。

<img width="1412" height="707" alt="1782957781033" src="https://github.com/user-attachments/assets/cbd35ac7-2f10-4545-8f7f-9cb92346f5dc" />
(取得的 csv 會把部分資料放到第一行)

## Changes

- 在 Google Sheets CSV 取得 URL 加上 `headers=1`，確保第一列會被當作欄位名稱解析。
- 新增 `UCA` staff group 到 staff 分組名稱、分組 key 與對應表。
- 在 staff 頁面的中英文 i18n 補上 `UCA` 分組顯示文字。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the new **UCA** staff group in the staff section, with matching labels in English and Chinese.
* **Bug Fixes**
  * Improved staff sheet imports so columns are read correctly from downloaded data.
  * Expanded staff group handling to recognize the new **UCA** value throughout the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->