### PR TITLE
chore: pre-bundle Vite deps to avoid dev page reloads

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -160,6 +160,12 @@ export default defineNuxtConfig({
     baseUrl: URL,
   },
 
+  vite: {
+    optimizeDeps: {
+      include: ['@vueuse/core', 'zod', 'leaflet'],
+    },
+  },
+
   gtag: {
     id: 'G-C9EMTMDSS1',
     enabled: process.env.NODE_ENV === 'production',


### PR DESCRIPTION
## What

Add `vite.optimizeDeps.include` for the deps Vite discovers *after* dev server startup, so it pre-bundles them on cold start instead of re-optimizing and triggering a full page reload mid-session.

```ts
vite: {
  optimizeDeps: {
    include: ['@vueuse/core', 'zod', 'leaflet'],
  },
}
```

## Why

The dev server logs these as late-discovered:

- Vite's own suggestion printed `include: ['@vueuse/core', 'zod']`
- `ℹ New dependencies found: leaflet (CJS)` → full page reload

## Verification

Cold start (cleared `node_modules/.cache/vite`) with the list applied:

- `leaflet` is pre-bundled at startup from `include` (no browser needed to trigger it)
- Curled all 9 routes — **zero** `new dependencies found` / `page reload` signals in the log
- `errx` is the only other optimized top-level dep; it's a transitive Nuxt-internal found during the initial scan (never flagged for reload), so it's intentionally excluded
- `pnpm lint` and `vue-tsc` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to pre-load additional commonly used libraries, improving startup and development performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->