### PR TITLE
fix: update room localization from 'zh-hans' to 'zh-hant' across components and API responses

### DIFF
--- a/app/components/feature/CpSessionList.vue
+++ b/app/components/feature/CpSessionList.vue
@@ -34,8 +34,8 @@ const sessions = computed(() => {
         start: session.start!.slice(11, 16),
         end: session.end!.slice(11, 16),
         room: locale.value === 'zh'
-          ? (session.room?.['zh-hans'] || session.room?.en || '')
-          : (session.room?.en || session.room?.['zh-hans'] || ''),
+          ? (session.room?.['zh-hant'] || session.room?.en || '')
+          : (session.room?.en || session.room?.['zh-hant'] || ''),
         tags: [],
       })),
     (session) => session.start,

--- a/app/components/feature/CpTrackSchedule.vue
+++ b/app/components/feature/CpTrackSchedule.vue
@@ -19,7 +19,7 @@ const CARD_GAP = 2 // 相鄰卡片間的細縫 px
 const DIFFICULTIES: SessionDifficulty[] = ['Elementary', 'Intermediate', 'Advanced', 'Professional']
 
 const localeKey = computed(() => (locale.value === 'zh' ? 'zh' : 'en'))
-const roomKey = computed(() => (localeKey.value === 'zh' ? 'zh-hans' : 'en') as 'zh-hans' | 'en')
+const roomKey = computed(() => (localeKey.value === 'zh' ? 'zh-hant' : 'en') as 'zh-hant' | 'en')
 
 function parseMinutes(iso: string) {
   const match = iso.match(/T(\d{2}):(\d{2})/)

--- a/app/components/feature/CpTrackSessionPanel.vue
+++ b/app/components/feature/CpTrackSessionPanel.vue
@@ -18,8 +18,8 @@ const localeKey = computed(() => (locale.value === 'zh' ? 'zh' : 'en'))
 const sessionInfo = computed(() => {
   const content = session[localeKey.value]
   const room = locale.value === 'zh'
-    ? (session.room?.['zh-hans'] || session.room?.en || '')
-    : (session.room?.en || session.room?.['zh-hans'] || '')
+    ? (session.room?.['zh-hant'] || session.room?.en || '')
+    : (session.room?.en || session.room?.['zh-hant'] || '')
 
   return {
     description: content.describe,

--- a/app/composables/useSessionFilter.ts
+++ b/app/composables/useSessionFilter.ts
@@ -12,7 +12,7 @@ interface UseSessionFilterOptions {
 }
 
 function roomId(session: SessionSummary) {
-  return session.room?.en || session.room?.['zh-hans'] || ''
+  return session.room?.en || session.room?.['zh-hant'] || ''
 }
 
 export function useSessionFilter({ sessionsByDay, selectedDay, locale }: UseSessionFilterOptions) {
@@ -28,7 +28,7 @@ export function useSessionFilter({ sessionsByDay, selectedDay, locale }: UseSess
   })
 
   function roomLabel(session: SessionSummary) {
-    const { en = '', 'zh-hans': zh = '' } = session.room ?? {}
+    const { en = '', 'zh-hant': zh = '' } = session.room ?? {}
     return isZh.value ? zh || en : en || zh
   }
 

--- a/app/pages/session/[id].vue
+++ b/app/pages/session/[id].vue
@@ -28,8 +28,8 @@ const sessionInfo = computed(() => {
 
   const content = sessionDetail.value[localeKey.value]
   const room = locale.value === 'zh'
-    ? (sessionDetail.value.room?.['zh-hans'] || sessionDetail.value.room?.en || '')
-    : (sessionDetail.value.room?.en || sessionDetail.value.room?.['zh-hans'] || '')
+    ? (sessionDetail.value.room?.['zh-hant'] || sessionDetail.value.room?.en || '')
+    : (sessionDetail.value.room?.en || sessionDetail.value.room?.['zh-hant'] || '')
 
   return {
     coWrite: sessionDetail.value.co_write ?? undefined,

--- a/app/pages/track/[id].vue
+++ b/app/pages/track/[id].vue
@@ -17,12 +17,12 @@ const localeKey = computed(() => (locale.value === 'zh' ? 'zh' : 'en'))
 const meta = computed(() => getTrackMeta(Number(route.params.id)))
 
 const title = computed(() =>
-  data.value?.name[localeKey.value === 'zh' ? 'zh-hans' : 'en'] ||
+  data.value?.name[localeKey.value === 'zh' ? 'zh-hant' : 'en'] ||
   data.value?.name.en ||
   '')
 
 const description = computed(() =>
-  data.value?.description[localeKey.value === 'zh' ? 'zh-hans' : 'en'] ||
+  data.value?.description[localeKey.value === 'zh' ? 'zh-hant' : 'en'] ||
   data.value?.description.en ||
   '')
 
@@ -65,7 +65,7 @@ function closeSession() {
 }
 
 const dayRooms = computed(() => {
-  const key = localeKey.value === 'zh' ? 'zh-hans' : 'en'
+  const key = localeKey.value === 'zh' ? 'zh-hant' : 'en'
   const names = daySessions.value
     .map((session) => session.room?.[key] || session.room?.en)
     .filter((name): name is string => Boolean(name))
@@ -73,7 +73,7 @@ const dayRooms = computed(() => {
 })
 
 const allRooms = computed(() => {
-  const key = localeKey.value === 'zh' ? 'zh-hans' : 'en'
+  const key = localeKey.value === 'zh' ? 'zh-hant' : 'en'
   const names = Object.values(data.value?.sessions ?? {})
     .flat()
     .map((session) => session.room?.[key] || session.room?.en)

--- a/app/pages/track/index.vue
+++ b/app/pages/track/index.vue
@@ -8,7 +8,7 @@ const localePath = useLocalePath()
 
 const { data } = await useFetch<TrackSummary[]>('/api/track')
 
-const localeKey = computed(() => (locale.value === 'zh' ? 'zh-hans' : 'en'))
+const localeKey = computed(() => (locale.value === 'zh' ? 'zh-hant' : 'en'))
 
 function trackName(track: TrackSummary) {
   return track.name[localeKey.value] || track.name.en || `#${track.id}`

--- a/server/api/session/[id]/index.get.ts
+++ b/server/api/session/[id]/index.get.ts
@@ -44,12 +44,12 @@ export default defineEventHandler(async (event) => {
     zh: {
       title: submission.title,
       describe: submission.abstract,
-      type: type.name['zh-hans'] || type.name.en,
+      type: type.name['zh-hant'] || type.name.en,
     },
     en: {
       title: answers.enTitle || submission.title,
       describe: answers.enDesc || submission.abstract,
-      type: type.name.en || type.name['zh-hans'],
+      type: type.name.en || type.name['zh-hant'],
     },
     tags: parseTags(submission.tags, data, parseDifficulty(answers.difficulty)),
     uri: `https://coscup.org/2026/session/${submission.code}`,

--- a/server/api/track/[id]/index.get.ts
+++ b/server/api/track/[id]/index.get.ts
@@ -27,7 +27,7 @@ export default defineEventHandler(async (event): Promise<TrackDetail> => {
   return {
     id: track.id,
     name: track.name,
-    description: track.description ?? { 'en': '', 'zh-hans': '' },
+    description: track.description ?? { 'en': '', 'zh-hant': '' },
     sessions: groupSessionsByDay(sessions),
   }
 })

--- a/server/utils/opass/pretalxToOpass.ts
+++ b/server/utils/opass/pretalxToOpass.ts
@@ -87,10 +87,10 @@ export function pretalxToOpass(pretalxData: PretalxResult) {
     return {
       id: type.id,
       zh: {
-        name: type.name['zh-hans'] || type.name.en,
+        name: type.name['zh-hant'] || type.name.en,
       },
       en: {
-        name: type.name.en || type.name['zh-hans'],
+        name: type.name.en || type.name['zh-hant'],
       },
     }
   })
@@ -109,10 +109,10 @@ export function pretalxToOpass(pretalxData: PretalxResult) {
       return {
         id: room.id,
         zh: {
-          name: room.name['zh-hans'] || room.name.en,
+          name: room.name['zh-hant'] || room.name.en,
         },
         en: {
-          name: room.name.en || room.name['zh-hans'],
+          name: room.name.en || room.name['zh-hant'],
         },
       }
     })

--- a/server/utils/pretalx/sessions.ts
+++ b/server/utils/pretalx/sessions.ts
@@ -29,12 +29,12 @@ export function buildSessionSummary(submission: Submission, data: PretalxResult)
     zh: {
       title: submission.title,
       describe: submission.abstract,
-      type: type.name['zh-hans'] || type.name.en,
+      type: type.name['zh-hant'] || type.name.en,
     },
     en: {
       title: answers.enTitle || submission.title,
       describe: answers.enDesc || submission.abstract,
-      type: type.name.en || type.name['zh-hans'],
+      type: type.name.en || type.name['zh-hant'],
     },
     tags: parseTags(submission.tags, data, parseDifficulty(answers.difficulty)),
     uri: `https://coscup.org/2026/session/${submission.code}`,

--- a/shared/types/pretalx.ts
+++ b/shared/types/pretalx.ts
@@ -14,7 +14,7 @@ export const PretalxTableSchema = z.enum(PRETALX_TABLES)
 
 export const PretalxLocaleSchema = z.object({
   'en': z.string().optional().default(''),
-  'zh-hans': z.string().optional().default(''),
+  'zh-hant': z.string().optional().default(''),
 })
 
 export const SubmissionSchema = z.object({


### PR DESCRIPTION
根據結果，發現繁體中文的 locale key 應該是 `zh-hant`。這應該也是 Track 頁面沒有正常切換中英文的原因。

```
$ curl -L -H "Authorization:Token <token>" 'https://pretalx.coscup.org/api/events/coscup-2026/tracks' | jq | head -20
{
  "count": 33,
  "next": null,
  "previous": null,
  "results": [
    {
      "id": 509,
      "name": {
        "en": "Miscellaneous Open Source Topics",
        "zh-hant": "綜合議程 - 各種開源議題"
      },
      "description": {
        "en": "As always, you are more than welcome to submit FLOSS-related proposals to the \"General Track\" even if your topic doesn’t strictly fit into the specific tracks listed above.\r\n\r\nWe invite submissions on any topic related to Openness and Open Source. Whether you're exploring open-source compliance, licensing, and legal issues; sharing your experience in fostering an open culture within your organization; or presenting an open-source project to recruit new contributors and enthusiasts—we want to hear from you. If it's about Open Source, it belongs here!\r\n\r\nPS. Previous tracks have been merged into this General Track:\r\n\r\n- [ 開源與職涯 / Open Source and Career Growth](https://hackmd.io/LuVNLvZHQB-c0dzTCztuYA)\r\n- [Open World Tour](https://hackmd.io/czfNE_qmQ26VNP4kch3f1Q)",
        "zh-hant": "一如往常的 COSCUP 一樣，如果您的主題找不到適合的議程軌投稿，您也可以提交 FLOSS 相關的稿件到綜合軌。\r\n\r\n歡迎分享任何與開放、開源等議題的內容，舉例來說，您想要探討開源合規、開源著作與法律、您所在的環境如何經營開放文化、或是您有開源專案要和大家分享，並希望號召更多投入開源的好朋友因為您的分享而吸引，都歡迎您投稿。\r\n\r\nPS. 過往的議程軌併入本綜合議程：\r\n\r\n- [開源與職涯 / Open Source and Career Growth](https://hackmd.io/LuVNLvZHQB-c0dzTCztuYA)\r\n- [Open World Tour](https://hackmd.io/czfNE_qmQ26VNP4kch3f1Q)"
      },
      "color": "#12ff00",
      "position": 31,
      "requires_access_code": true
    },
    {
```