### PR TITLE
feat: add room-timeline (教室時間軸) schedule view

### DIFF
--- a/app/components/feature/CpSessionTable.vue
+++ b/app/components/feature/CpSessionTable.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
-import type { SessionSummary } from '#shared/types/session'
+import type { SessionSummary, SessionTrack } from '#shared/types/session'
+import { StorageSerializers, useLocalStorage } from '@vueuse/core'
 import { useI18n } from '#imports'
 import { useDragScroll } from '~/composables/useDragScroll'
 import { useFavoriteLabel, useFavorites } from '~/composables/useFavorites'
 import { useRealtime } from '~/composables/useRealtime'
-import CpSessionItem from './CpSessionItem.vue'
+import { buildTrackColorMap, isMainTrack, trackKey } from '~/utils/tracks'
 
 const { sessions: _sessions, day, timeRange, interval, rowHeight, columnWidth, preview = false } = defineProps<{
   day: string
@@ -17,7 +18,7 @@ const { sessions: _sessions, day, timeRange, interval, rowHeight, columnWidth, p
   preview?: boolean
 }>()
 
-const { locale } = useI18n()
+const { t, locale } = useI18n()
 const { time } = useRealtime()
 const route = useRoute()
 const localePath = useLocalePath()
@@ -25,6 +26,12 @@ const { isFavorite, toggleFavorite } = useFavorites()
 const favoriteLabel = useFavoriteLabel()
 
 const { containerRef, isDragging } = useDragScroll({ scrollTarget: 'window' })
+
+// Time-axis column width and header row height, matching the Figma room-timeline spec.
+const TIME_COL_WIDTH = 64
+const HEADER_HEIGHT = 58
+
+const isZh = computed(() => locale.value !== 'en')
 
 function sessionPath(id: string) {
   return localePath({ path: `/session/${id}`, query: route.query })
@@ -39,16 +46,22 @@ function parseMinutes(isoStr: string) {
   return Number(hours) * 60 + Number(minutes)
 }
 
+function localeName(name?: SessionTrack['name']) {
+  const { en = '', 'zh-hant': zh = '' } = name ?? {}
+  return isZh.value ? zh || en : en || zh
+}
+
 const timeStart = computed(() => parseMinutes(`T${timeRange[0]}`))
 const timeEnd = computed(() => parseMinutes(`T${timeRange[1]}`))
 const totalGridRows = computed(() => Math.round((timeEnd.value - timeStart.value) / interval))
 
-function formatTime(minutes: number) {
+function formatClock(minutes: number) {
   const h = Math.floor(minutes / 60)
   const m = minutes % 60
   return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`
 }
 
+// Grid rows: header is row 1, the first time slot is row 2.
 function toRow(minutes: number) {
   return Math.round((minutes - timeStart.value) / interval) + 2
 }
@@ -75,162 +88,375 @@ function compareRooms(a: string, b: string) {
   return rankDiff || a.localeCompare(b)
 }
 
+const daySessions = computed(() =>
+  (_sessions ?? []).filter((session) =>
+    session.start?.startsWith(day) && session.end && session.room?.en,
+  ),
+)
+
+// A track keeps its colour across both table views (see ~/utils/tracks). Build from the whole
+// day (not just roomed sessions) so the index order matches CpSessionTrackTable exactly.
+const trackColors = computed(() =>
+  buildTrackColorMap((_sessions ?? []).filter((session) => session.start?.startsWith(day) && session.end)),
+)
+
+// Rooms are the columns. Each carries the track name(s) hosted there as a subtitle.
+const roomsRaw = computed(() => {
+  const byCode = new Map<string, { code: string, trackNames: Set<string>, isMain: boolean }>()
+  for (const session of daySessions.value) {
+    const code = session.room!.en
+    let info = byCode.get(code)
+    if (!info) {
+      info = { code, trackNames: new Set(), isMain: false }
+      byCode.set(code, info)
+    }
+    const name = localeName(session.track?.name)
+    if (name) {
+      info.trackNames.add(name)
+    }
+    if (isMainTrack(session.track?.name)) {
+      info.isMain = true
+    }
+  }
+  return [...byCode.values()].map((room) => ({
+    code: room.code,
+    subtitle: [...room.trackNames].join('、'),
+    isMain: room.isMain,
+  }))
+})
+
+// null = never visited (pin the main-track room by default); [] = user unpinned everything.
+const pinnedRooms = useLocalStorage<string[] | null>('coscup-pinned-rooms', null, {
+  serializer: StorageSerializers.object,
+})
+const isPinned = (code: string) => (pinnedRooms.value ?? []).includes(code)
+
+function togglePin(code: string) {
+  const current = pinnedRooms.value ?? []
+  pinnedRooms.value = current.includes(code)
+    ? current.filter((c) => c !== code)
+    : [...current, code]
+}
+
+// Room hosting the main track, derived event-wide so the first-visit pin doesn't depend on the day.
+const defaultMainRoom = computed(() => {
+  const main = (_sessions ?? []).find((session) => isMainTrack(session.track?.name) && session.room?.en)
+  return main?.room?.en ?? null
+})
+
+watch(defaultMainRoom, (code) => {
+  if (pinnedRooms.value === null && code) {
+    pinnedRooms.value = [code]
+  }
+}, { immediate: true })
+
+// Pinned rooms float to the front (in pin order); the rest keep the venue ordering.
 const rooms = computed(() => {
-  if (!_sessions) {
-    return []
-  }
-
-  const rooms = _sessions
-    .map((session) => session.room?.en)
-    .filter((value) => value !== undefined)
-
-  return [...new Set(rooms)].sort(compareRooms) satisfies string[]
-})
-
-const timeLabels = computed(() => {
-  const labels: { label: string, row: number }[] = []
-  let m = Math.ceil(timeStart.value / 30) * 30
-  while (m < timeEnd.value) {
-    labels.push({ label: formatTime(m), row: toRow(m) })
-    m += 30
-  }
-  return labels
-})
-
-const sessions = computed(() => {
-  if (!_sessions) {
-    return []
-  }
-
-  return _sessions
-    .filter((session) => [
-      session.start?.startsWith(day),
-      session.end,
-      session.room,
-    ].every(Boolean))
-    .map((session) => {
-      const startMins = parseMinutes(session.start!)
-      const endMins = parseMinutes(session.end!)
-
-      const { title } = session[locale.value]
-      const speaker = session.speakers?.map((s) => s[locale.value].name).join(', ')
-
-      return {
-        id: session.id,
-        title,
-        speaker,
-        start: session.start!.slice(11, 16),
-        end: session.end!.slice(11, 16),
-        row: [toRow(startMins), toRow(endMins)],
-        col: rooms.value.findIndex((r) => session.room!.en === r) + 2,
-        tags: [],
+  const pinOrder = new Map((pinnedRooms.value ?? []).map((code, index) => [code, index]))
+  return [...roomsRaw.value]
+    .sort((a, b) => compareRooms(a.code, b.code))
+    .sort((a, b) => {
+      const ai = pinOrder.get(a.code)
+      const bi = pinOrder.get(b.code)
+      if (ai != null && bi != null) {
+        return ai - bi
       }
+      return (ai != null ? 0 : 1) - (bi != null ? 0 : 1)
     })
 })
 
-const nowLineTop = computed(() => {
-  const formatter = new Intl.DateTimeFormat('en-US', {
+// Hour labels down the time axis; assumes the range starts on the hour (real data is 09:00).
+const timeBands = computed(() => {
+  const bands: { label: string, rowStart: number, rowEnd: number }[] = []
+  let m = Math.ceil(timeStart.value / 60) * 60
+  while (m < timeEnd.value) {
+    const next = Math.min(m + 60, timeEnd.value)
+    bands.push({ label: `${Math.floor(m / 60)}:00`, rowStart: toRow(m), rowEnd: toRow(next) })
+    m += 60
+  }
+  return bands
+})
+
+// Horizontal grid lines every 30 min: solid on the hour, dashed on the half-hour.
+const gridLines = computed(() => {
+  const lines: { row: number, hour: boolean }[] = []
+  let m = Math.ceil(timeStart.value / 30) * 30
+  while (m < timeEnd.value) {
+    lines.push({ row: toRow(m), hour: m % 60 === 0 })
+    m += 30
+  }
+  return lines
+})
+
+function nowMinutes() {
+  const parts = new Intl.DateTimeFormat('en-US', {
     timeZone: 'Asia/Taipei',
     hour: 'numeric',
     minute: 'numeric',
     second: 'numeric',
     hour12: false,
-  })
-  const parts = formatter.formatToParts(time.value)
-  const h = Number(parts.find((p) => p.type === 'hour')!.value)
-  const m = Number(parts.find((p) => p.type === 'minute')!.value)
-  const s = Number(parts.find((p) => p.type === 'second')!.value)
-  const mins = h * 60 + m + s / 60
-  return rowHeight + ((mins - timeStart.value) / interval) * rowHeight
-})
+  }).formatToParts(time.value)
+  const get = (type: string) => Number(parts.find((p) => p.type === type)!.value)
+  return get('hour') * 60 + get('minute') + get('second') / 60
+}
 
-const showRealtimeLine = computed(() => {
-  const iso = time.value.toISOString()
-  const todayStr = iso.slice(0, 10)
-  return day === todayStr && timeStart.value <= parseMinutes(iso) && parseMinutes(iso) <= timeEnd.value
-})
+const nowMins = computed(() => nowMinutes())
+const nowLineTop = computed(() => HEADER_HEIGHT + ((nowMins.value - timeStart.value) / interval) * rowHeight)
+const nowLabel = computed(() => formatClock(Math.floor(nowMins.value)))
+
+// Taipei-local date (YYYY-MM-DD, lexically comparable to `day`); toISOString() is UTC and 8h off.
+const todayTaipei = computed(() =>
+  new Intl.DateTimeFormat('en-CA', { timeZone: 'Asia/Taipei' }).format(time.value),
+)
+
+const showRealtimeLine = computed(() =>
+  day === todayTaipei.value && timeStart.value <= nowMins.value && nowMins.value <= timeEnd.value,
+)
+
+const DIFFICULTY_TAGS = ['Elementary', 'Intermediate', 'Advanced']
+function difficultyLabel(tags: string[]) {
+  const level = tags.find((tag) => DIFFICULTY_TAGS.includes(tag))
+  // ponytail: badge shows the difficulty (the one clean, well-populated tag), else "Other".
+  return level ? t(`difficulty.${level}`) : t('other')
+}
+
+const sessions = computed(() =>
+  daySessions.value.map((session) => {
+    const startMins = parseMinutes(session.start!)
+    const endMins = parseMinutes(session.end!)
+    // Past / in-progress sessions render dimmed; future sessions render bright. Judge by Taipei
+    // date/time so a finished day stays dimmed even when the now line is out of range.
+    const isPast = day < todayTaipei.value
+      ? true
+      : day > todayTaipei.value ? false : startMins <= nowMins.value
+
+    // Card height is the cell minus the 4px vertical inset (my-[2px]). A 30-min card (~56px)
+    // only fits the 2-line title + time, so drop the speaker below the height where all three
+    // fit and nothing is clipped mid-line. Title and time+tag always show.
+    const cardHeightPx = ((endMins - startMins) / interval) * rowHeight - 4
+
+    return {
+      id: session.id,
+      title: session[locale.value].title,
+      speaker: session.speakers?.map((s) => s[locale.value].name).join(', '),
+      showSpeaker: cardHeightPx >= 72,
+      start: session.start!.slice(11, 16).replace(/^0/, ''),
+      end: session.end!.slice(11, 16).replace(/^0/, ''),
+      tag: difficultyLabel(session.tags),
+      row: [toRow(startMins), toRow(endMins)],
+      col: rooms.value.findIndex((r) => r.code === session.room!.en) + 2,
+      color: trackColors.value.get(trackKey(session)) ?? '#e76f51',
+      isPast,
+    }
+  }),
+)
 </script>
 
 <template>
   <div
     ref="containerRef"
-    class="border border-gray-200 rounded-xl grid relative overflow-clip isolate"
+    class="border border-[rgba(26,26,26,0.12)] rounded-[8px] grid relative overflow-clip isolate"
     :class="isDragging ? 'cursor-grabbing select-none' : 'cursor-grab'"
     :style="{
-      gridTemplateColumns: `4.5rem repeat(${rooms.length}, ${columnWidth}px)`,
-      gridTemplateRows: `3rem repeat(${totalGridRows}, ${rowHeight}px)`,
+      gridTemplateColumns: `${TIME_COL_WIDTH}px repeat(${rooms.length}, ${columnWidth}px)`,
+      gridTemplateRows: `${HEADER_HEIGHT}px repeat(${totalGridRows}, ${rowHeight}px)`,
     }"
   >
+    <!-- Top-left corner cell (empty) -->
     <div
-      class="border-b border-gray-200 bg-gray-50 left-0 top-0 sticky z-sticky"
-      :style="{
-        'grid-row': 1,
-        'grid-column': 1,
-      }"
+      class="border-b border-r border-[rgba(26,26,26,0.12)] bg-[#faf9f7] left-0 top-0 sticky z-modal"
+      :style="{ 'grid-row': 1, 'grid-column': 1 }"
     />
 
+    <!-- Room header cells -->
     <div
       v-for="(room, i) in rooms"
-      :key="room"
-      class="text-sm text-primary-400 font-medium border-b border-gray-200 bg-gray-50 flex items-center top-0 justify-center sticky z-sticky"
-      :style="{
-        'grid-row': 1,
-        'grid-column': i + 2,
-      }"
+      :key="room.code"
+      class="py-[10px] pl-[12px] pr-[13px] border-b border-r border-[rgba(26,26,26,0.12)] bg-[#faf9f7] flex flex-col items-start top-0 relative sticky z-sticky overflow-hidden"
+      :class="isPinned(room.code) ? 'shadow-[inset_0px_-3px_0px_0px_#3b82f6]' : ''"
+      :style="{ 'grid-row': 1, 'grid-column': i + 2 }"
+      @pointerdown.stop
     >
-      {{ room }}
+      <!-- Pinned column tint -->
+      <div
+        v-if="isPinned(room.code)"
+        class="bg-[rgba(239,246,255,0.6)] pointer-events-none inset-0 absolute"
+      />
+      <div class="flex w-full items-center justify-between relative">
+        <div class="flex gap-[4px] min-w-0 items-center">
+          <Icon
+            v-if="isPinned(room.code)"
+            class="text-[12px] text-[#1447e6] shrink-0"
+            name="tabler:pin-filled"
+          />
+          <span
+            class="text-[12px] leading-[16px] font-bold font-mono whitespace-nowrap truncate"
+            :class="isPinned(room.code) ? 'text-[#1447e6]' : 'text-[#1a1a1a]'"
+          >{{ room.code }}</span>
+        </div>
+        <button
+          :aria-label="isPinned(room.code) ? t('unpinRoom') : t('pinRoom')"
+          :aria-pressed="isPinned(room.code)"
+          class="p-[4px] rounded-[4px] flex shrink-0 cursor-pointer items-center"
+          :class="isPinned(room.code) ? 'bg-[#dbeafe] text-[#1447e6]' : 'text-[#99a1af] hover:text-[#4a5565]'"
+          :title="isPinned(room.code) ? t('unpinRoom') : t('pinRoom')"
+          type="button"
+          @click="togglePin(room.code)"
+        >
+          <Icon
+            class="text-[12px]"
+            :name="isPinned(room.code) ? 'tabler:pin-filled' : 'tabler:pin'"
+          />
+        </button>
+      </div>
+      <p
+        v-if="room.subtitle"
+        class="text-[10px] text-[#737373] leading-[15px] pt-[2px] w-full whitespace-nowrap relative overflow-hidden"
+      >
+        {{ room.subtitle }}
+      </p>
     </div>
 
-    <template
-      v-for="label in timeLabels"
-      :key="label.label"
+    <!-- Time-axis hour bands (sticky left column) -->
+    <div
+      v-for="band in timeBands"
+      :key="band.label"
+      class="pr-[8px] pt-[3px] border-b border-r border-b-[rgba(26,26,26,0.05)] border-r-[rgba(26,26,26,0.12)] bg-[#faf9f7] flex items-start left-0 justify-end sticky z-dropdown"
+      :style="{ 'grid-row': `${band.rowStart} / ${band.rowEnd}`, 'grid-column': 1 }"
     >
-      <div
-        class="text-xs text-gray-400 pr-2 pt-0.5 text-right border-t border-gray-100 bg-gray-50 flex items-start left-0 justify-center sticky z-content"
-        :style="{
-          'grid-row': `${label.row} / ${label.row + 30 / interval}`,
-          'grid-column': 1,
-        }"
-      >
-        {{ label.label }}
-      </div>
-      <div
-        v-for="(_, i) in rooms"
-        :key="i"
-        class="border-t border-gray-100"
-        :style="{
-          'grid-row': label.row,
-          'grid-column': i + 2,
-        }"
-      />
-    </template>
+      <span class="text-[10px] text-[#737373] leading-[10px] font-mono whitespace-nowrap">{{ band.label }}</span>
+    </div>
 
-    <CpSessionItem
+    <!-- Vertical room dividers -->
+    <div
+      v-for="(room, i) in rooms"
+      :key="`div-${room.code}`"
+      class="border-r border-[rgba(26,26,26,0.12)] pointer-events-none"
+      :style="{ 'grid-row': `2 / -1`, 'grid-column': i + 2 }"
+    />
+
+    <!-- Horizontal grid lines (solid on the hour, dashed on the half-hour) -->
+    <div
+      v-for="line in gridLines"
+      :key="`line-${line.row}`"
+      class="h-px pointer-events-none"
+      :class="line.hour ? 'border-t border-[#dcdcdc]' : 'border-t border-dashed border-[#ebebeb]'"
+      :style="{ 'grid-row': line.row, 'grid-column': `2 / -1` }"
+    />
+
+    <!-- Session cards. Inset within the grid cell (Figma: 4px sides, 2px top/bottom) so
+         adjacent sessions are visually separated and the favorited outline has room. -->
+    <div
       v-for="session in sessions"
       :key="session.id"
-      class="h-full overflow-hidden"
-      :end="session.end"
-      :favorite="preview || isFavorite(session.id)"
-      :favorite-label="favoriteLabel(session.id, preview)"
-      :readonly="preview"
-      :speaker="session.speaker"
-      :start="session.start"
+      class="mx-[4px] my-[2px] rounded-[4px] relative overflow-hidden"
       :style="{
         'grid-row': `${session.row[0]} / ${session.row[1]}`,
         'grid-column': session.col,
+        'backgroundColor': session.color,
+        'boxShadow': (preview || isFavorite(session.id))
+          ? '0 0 0 1px #ffffff, 0 0 0 3px #fdc700'
+          : '0px 1px 1.5px rgba(0,0,0,0.1), 0px 1px 1px rgba(0,0,0,0.1)',
       }"
-      :tags="session.tags"
-      :title="session.title"
-      :to="sessionPath(session.id)"
-      @toggle-favorite="toggleFavorite(session.id)"
-    />
+    >
+      <!-- Content -->
+      <div class="px-[8px] py-[4px] flex flex-col h-full w-full overflow-hidden">
+        <h3
+          class="text-[12px] text-white leading-[16.5px] font-semibold line-clamp-2"
+          :style="{ filter: 'drop-shadow(0px 1px 2px rgba(0,0,0,0.15))' }"
+        >
+          {{ session.title }}
+        </h3>
+        <p
+          v-if="session.showSpeaker"
+          class="text-[10px] text-white/80 leading-[15px] pt-[2px] whitespace-nowrap overflow-hidden"
+        >
+          {{ session.speaker || '\u00A0' }}
+        </p>
+        <!-- Spacer pushes the time/tag row to the bottom; on short cards it collapses so the
+             overflow clips the bottom row rather than overlapping the speaker. -->
+        <div class="flex-1" />
+        <div class="flex gap-[6px] items-center">
+          <!-- The tag pill centers its own text; the mono digits render ~1px high in their
+               line box, so nudge the time down 1px to optically center it against the tag. -->
+          <time class="text-[9px] text-white/80 leading-none font-mono whitespace-nowrap top-[1px] relative">{{ session.start }}–{{ session.end }}</time>
+          <span
+            v-if="session.tag"
+            class="text-[8px] text-white/90 leading-none px-[4px] py-[3px] rounded-[4px] bg-white/20 whitespace-nowrap"
+          >{{ session.tag }}</span>
+        </div>
+      </div>
 
-    <ClientOnly>
-      <div
-        v-if="showRealtimeLine"
-        class="border-t-1 border-red-500 w-full pointer-events-none left-0 absolute z-content"
-        :style="{ top: `${nowLineTop}px` }"
+      <!-- Overlay link (transparent), so the bookmark stays a clickable sibling, not nested. -->
+      <NuxtLink
+        :aria-label="session.title"
+        class="inset-0 absolute"
+        :draggable="false"
+        :to="sessionPath(session.id)"
+        @dragstart.prevent
       />
+
+      <!-- Dimmed state (past / in progress) -->
+      <div
+        v-if="session.isPast"
+        class="bg-black/30 pointer-events-none inset-0 absolute"
+      />
+
+      <!-- Favorite bookmark (bottom-right, so it never overlaps the title) -->
+      <span
+        v-if="preview"
+        aria-hidden="true"
+        class="text-[12px] text-white leading-none p-[4px] rounded-[4px] bg-black/10 pointer-events-none bottom-[6px] right-[6px] absolute"
+      >
+        <Icon name="tabler:bookmark-filled" />
+      </span>
+      <button
+        v-else
+        :aria-label="favoriteLabel(session.id)"
+        :aria-pressed="isFavorite(session.id)"
+        class="text-[12px] text-white leading-none p-[4px] rounded-[4px] bg-black/10 cursor-pointer transition-colors bottom-[6px] right-[6px] absolute hover:bg-black/20"
+        type="button"
+        @click.prevent.stop="toggleFavorite(session.id)"
+      >
+        <Icon :name="isFavorite(session.id) ? 'tabler:bookmark-filled' : 'tabler:bookmark'" />
+      </button>
+    </div>
+
+    <!-- Current-time ("now") line + badge -->
+    <ClientOnly>
+      <template v-if="showRealtimeLine">
+        <div
+          class="bg-[#fb2c36] h-px pointer-events-none absolute z-content"
+          :style="{ top: `${nowLineTop}px`, left: `${TIME_COL_WIDTH}px`, right: 0 }"
+        />
+        <div
+          class="pr-[2px] flex pointer-events-none left-0 justify-end absolute z-modal"
+          :style="{ top: `${nowLineTop - 6}px`, width: `${TIME_COL_WIDTH}px` }"
+        >
+          <span class="pr-1 rounded-[4px] bg-[#fb2c36] flex h-[13px] w-[35px] items-center justify-end">
+            <span class="text-[9px] text-white leading-[9px] font-mono whitespace-nowrap">{{ nowLabel }}</span>
+          </span>
+        </div>
+      </template>
     </ClientOnly>
   </div>
 </template>
+
+<i18n lang="yaml">
+  en:
+    other: 'Other'
+    pinRoom: 'Pin room'
+    unpinRoom: 'Unpin room'
+    difficulty:
+      Elementary: 'Beginner'
+      Intermediate: 'Intermediate'
+      Advanced: 'Advanced'
+  zh:
+    other: '其他'
+    pinRoom: '釘選教室'
+    unpinRoom: '取消釘選'
+    difficulty:
+      Elementary: '入門'
+      Intermediate: '中階'
+      Advanced: '進階'
+</i18n>

--- a/app/components/feature/CpSessionTrackTable.vue
+++ b/app/components/feature/CpSessionTrackTable.vue
@@ -4,6 +4,7 @@ import { StorageSerializers, useLocalStorage } from '@vueuse/core'
 import { useI18n } from 'vue-i18n'
 import { useDragScroll } from '~/composables/useDragScroll'
 import { useRealtime } from '~/composables/useRealtime'
+import { TRACK_COLORS } from '~/utils/tracks'
 
 const { sessions: _sessions, day, timeRange, interval, rowHeight, columnWidth } = defineProps<{
   day: string
@@ -22,32 +23,6 @@ const { containerRef, isDragging } = useDragScroll({ scrollTarget: 'window' })
 
 // Width of the sticky track-label column; keep in sync with the grid-template value below.
 const LABEL_WIDTH = 280
-
-// Per-track solid card background, ordered by sorted track index (from the Figma spec §5).
-const TRACK_COLORS = [
-  '#e76f51',
-  '#ff6b6b',
-  '#4ecdc4',
-  '#45b7d1',
-  '#ffa07a',
-  '#98d8c8',
-  '#f7dc6f',
-  '#bb8fce',
-  '#85c1e2',
-  '#f8b195',
-  '#f67280',
-  '#c06c84',
-  '#6c5b7b',
-  '#355c7d',
-  '#2a9d8f',
-  '#264653',
-  '#e9c46a',
-  '#f4a261',
-  '#e63946',
-  '#457b9d',
-  '#1d3557',
-  '#a8dadc',
-]
 
 const isZh = computed(() => locale.value !== 'en')
 

--- a/app/pages/session.vue
+++ b/app/pages/session.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { TableViewMode } from '~/components/feature/CpSessionFilterBar.vue'
+import { useStorage } from '@vueuse/core'
 import { prerenderRoutes } from 'nuxt/app'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from '#imports'
@@ -89,7 +90,9 @@ const {
   locale,
 })
 
-const viewMode = ref<TableViewMode>('track')
+// Persist the table/track choice across refreshes and language switches. localStorage is
+// shared across the /en and /zh routes, and this toggle only renders inside <ClientOnly>.
+const viewMode = useStorage<TableViewMode>('coscup-session-view-mode', 'track')
 
 type SessionView = 'all' | 'favorite'
 const view = ref<SessionView>('all')
@@ -235,7 +238,7 @@ definePageMeta({
             :sessions="displayedSessions"
           />
           <CpSessionTrackTable
-            v-if="displayedSessions.length > 0 && viewMode === 'track'"
+            v-if="displayedSessions.length > 0 && viewMode !== 'table'"
             class="hidden sm:grid"
             :column-width="20"
             :day="selectedDay"

--- a/app/pages/session.vue
+++ b/app/pages/session.vue
@@ -247,11 +247,11 @@ definePageMeta({
           <CpSessionTable
             v-if="displayedSessions.length > 0 && viewMode === 'table'"
             class="hidden sm:grid"
-            :column-width="200"
+            :column-width="180"
             :day="selectedDay"
             :interval="5"
             :preview="isSharing"
-            :row-height="50"
+            :row-height="10"
             :sessions="displayedSessions"
             :time-range="['09:00', '17:30']"
           />

--- a/app/utils/tracks.ts
+++ b/app/utils/tracks.ts
@@ -1,0 +1,59 @@
+import type { SessionSummary, SessionTrack } from '#shared/types/session'
+
+// Per-track solid card background, ordered by sorted track index (from the Figma spec §5).
+// Shared by both the room table (CpSessionTable) and the track table (CpSessionTrackTable)
+// so a given track keeps the same colour in either view. Keep the two in sync.
+export const TRACK_COLORS = [
+  '#e76f51',
+  '#ff6b6b',
+  '#4ecdc4',
+  '#45b7d1',
+  '#ffa07a',
+  '#98d8c8',
+  '#f7dc6f',
+  '#bb8fce',
+  '#85c1e2',
+  '#f8b195',
+  '#f67280',
+  '#c06c84',
+  '#6c5b7b',
+  '#355c7d',
+  '#2a9d8f',
+  '#264653',
+  '#e9c46a',
+  '#f4a261',
+  '#e63946',
+  '#457b9d',
+  '#1d3557',
+  '#a8dadc',
+]
+
+// Track-less sessions collapse into one fallback bucket so nothing disappears.
+export const NO_TRACK = '__none__'
+
+export function trackKey(session: SessionSummary): string {
+  return session.track?.id != null ? String(session.track.id) : NO_TRACK
+}
+
+// Match by name (either locale) since Pretalx track ids aren't stable across events.
+const MAIN_TRACK_NAMES = ['主議程', 'Main Session Track']
+export function isMainTrack(name?: SessionTrack['name']): boolean {
+  return MAIN_TRACK_NAMES.includes(name?.['zh-hant'] ?? '') || MAIN_TRACK_NAMES.includes(name?.en ?? '')
+}
+
+/**
+ * Assign a stable colour per track: distinct tracks sorted by id (track-less last),
+ * indexed into the palette. Both table views build this from the same day's sessions,
+ * so a track resolves to the same colour in either layout.
+ */
+export function buildTrackColorMap(sessions: SessionSummary[]): Map<string, string> {
+  const order = new Map<string, number>()
+  for (const session of sessions) {
+    const key = trackKey(session)
+    if (!order.has(key)) {
+      order.set(key, session.track?.id ?? Number.POSITIVE_INFINITY)
+    }
+  }
+  const sorted = [...order.entries()].sort((a, b) => a[1] - b[1])
+  return new Map(sorted.map(([key], index) => [key, TRACK_COLORS[index % TRACK_COLORS.length]!]))
+}


### PR DESCRIPTION
依 Figma 設計實作桌面版「教室時間軸模式」議程表（以教室為欄、時間為列），作為 #238「議程軌模式」的對應檢視，並在重新整理或切換語言後保留檢視選擇。

## 變更內容
- 重寫 `CpSessionTable`：以教室為欄、時間為列，作為 `CpSessionTrackTable`（議程軌模式）的直向對應版本。
- 教室欄標題加入釘選按鈕與該教室議程軌名稱副標；釘選的教室置頂並套用藍色高亮（存於 `coscup-pinned-rooms`，比照議程軌釘選）。
- 議程卡片依議程軌上色：標題（兩行截斷）、講者（卡片夠高才顯示）、時間、難度標籤；收藏書籤置於右下，收藏後顯示外框。
- 每小時時間軸、整點實線／半點虛線格線、目前時間紅線與時間徽章。
- 卡片於格子內留白，使相鄰議程有視覺區隔並保留收藏外框空間；放大格子尺寸以維持卡片大小不變。
- 抽出議程軌配色與共用函式至 `app/utils/tracks.ts`，讓教室／議程軌兩種檢視對同一議程軌給相同顏色。
- 以 `localStorage`（`coscup-session-view-mode`）保存議程軌／教室檢視選擇，取代原本的暫時性 `ref`；於 `<ClientOnly>` 內渲染，無 SSG hydration 問題，異常值回退為議程軌檢視。

## 略過項目
- 未替換為 Figma 字型（Archivo／DM Sans），沿用專案字型 + `font-mono`。
- 手機版 `CpSessionList` 維持原樣。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned the session table with clearer room organization, track colors, localized titles, speakers, and time displays.
  * Pin or unpin rooms to keep preferred rooms at the top; selections persist between visits.
  * Added a real-time indicator showing the current time in Taiwan time.
  * Session cards now visually distinguish past sessions and adapt displayed details to available space.
  * View mode selection persists across refreshes and language changes.

* **Improvements**
  * Track colors are now consistent across session views.
  * Improved handling and display of sessions without assigned tracks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->