### PR TITLE
處理新議程表的功能

### DIFF
--- a/app/components/feature/CpSessionFilterBar.vue
+++ b/app/components/feature/CpSessionFilterBar.vue
@@ -8,6 +8,7 @@ export type TableViewMode = 'track' | 'table'
 
 defineProps<{
   tagOptions: FilterOption[]
+  preview?: boolean
 }>()
 
 const viewMode = defineModel<TableViewMode>('viewMode', { default: () => 'track' })
@@ -31,6 +32,7 @@ const viewModeItems = computed<{ key: TableViewMode, label: string, icon: string
         :items="viewModeItems"
       />
       <CpSessionFilterDropdown
+        v-if="!preview"
         v-model="selectedTagIds"
         icon="tabler:tag"
         :options="tagOptions"
@@ -39,7 +41,10 @@ const viewModeItems = computed<{ key: TableViewMode, label: string, icon: string
     </div>
 
     <!-- Controls below the search field on mobile, to its left on desktop. -->
-    <div class="flex flex-col-reverse gap-3 items-center sm:flex-row sm:items-center">
+    <div
+      v-if="!preview"
+      class="flex flex-col-reverse gap-3 items-center sm:flex-row sm:items-center"
+    >
       <slot name="controls" />
 
       <CpTextField

--- a/app/components/feature/CpSessionList.vue
+++ b/app/components/feature/CpSessionList.vue
@@ -10,11 +10,11 @@ const { sessions: _sessions, preview = false } = defineProps<{
   preview?: boolean
 }>()
 
-const { locale } = useI18n()
+const { locale, t } = useI18n()
 const route = useRoute()
 const localePath = useLocalePath()
 const { isFavorite, toggleFavorite } = useFavorites()
-const favoriteLabel = useFavoriteLabel()
+const favoriteLabel = useFavoriteLabel(t)
 
 function sessionPath(id: string) {
   return localePath({ path: `/session/${id}`, query: route.query })

--- a/app/components/feature/CpSessionList.vue
+++ b/app/components/feature/CpSessionList.vue
@@ -74,3 +74,12 @@ const times = computed(() => Object.keys(sessions.value).sort())
     </section>
   </div>
 </template>
+
+<i18n lang="yaml">
+  en:
+    add: 'Add to favorites'
+    remove: 'Remove from favorites'
+  zh:
+    add: '加入收藏'
+    remove: '取消收藏'
+</i18n>

--- a/app/components/feature/CpSessionTable.vue
+++ b/app/components/feature/CpSessionTable.vue
@@ -23,7 +23,7 @@ const { time } = useRealtime()
 const route = useRoute()
 const localePath = useLocalePath()
 const { isFavorite, toggleFavorite } = useFavorites()
-const favoriteLabel = useFavoriteLabel()
+const favoriteLabel = useFavoriteLabel(t)
 
 const { containerRef, isDragging } = useDragScroll({ scrollTarget: 'window' })
 

--- a/app/components/feature/CpSessionTable.vue
+++ b/app/components/feature/CpSessionTable.vue
@@ -447,6 +447,8 @@ const sessions = computed(() =>
     other: 'Other'
     pinRoom: 'Pin room'
     unpinRoom: 'Unpin room'
+    add: 'Add to favorites'
+    remove: 'Remove from favorites'
     difficulty:
       Elementary: 'Beginner'
       Intermediate: 'Intermediate'
@@ -455,6 +457,8 @@ const sessions = computed(() =>
     other: '其他'
     pinRoom: '釘選教室'
     unpinRoom: '取消釘選'
+    add: '加入收藏'
+    remove: '取消收藏'
     difficulty:
       Elementary: '入門'
       Intermediate: '中階'

--- a/app/components/feature/CpSessionTrackTable.vue
+++ b/app/components/feature/CpSessionTrackTable.vue
@@ -101,26 +101,51 @@ function togglePin(key: string) {
 }
 
 const tracks = computed(() => {
-  const byKey = new Map<string, { key: string, order: number, name: string, room: string, isMain: boolean }>()
+  const byKey = new Map<string, { key: string, trackId: string | null, order: number, name: string, room: string, roomEn: string, isMain: boolean }>()
   for (const session of daySessions.value) {
     const id = session.track?.id
-    const key = id != null ? String(id) : NO_TRACK
+    const trackId = id != null ? String(id) : null
+    const roomEn = session.room?.en ?? ''
+    const key = `${trackId ?? NO_TRACK}__${roomEn}`
     if (!byKey.has(key)) {
       byKey.set(key, {
         key,
+        trackId,
         order: id ?? Number.POSITIVE_INFINITY,
         name: session.track ? localeName(session.track.name) : t('other'),
         room: localeName(session.room),
+        roomEn,
         isMain: isMainTrack(session.track?.name),
       })
     }
   }
-  // Color by stable track-id order so a track keeps its color regardless of pin state. Pinned
-  // group is ordered by pin order (newest last); unpinned keep id order (Array.sort is stable).
+
+  const values = [...byKey.values()]
+
+  // Assign color by unique track order so same track always gets the same color,
+  // even when split across multiple rooms.
+  const uniqueOrders = [...new Set(values.map((t) => t.order))].sort((a, b) => a - b)
+  const colorByOrder = new Map(uniqueOrders.map((order, i) => [order, TRACK_COLORS[i % TRACK_COLORS.length]!]))
+
+  // For tracks spanning multiple rooms, use the highest-priority room in the group
+  // to determine the track group's position in the overall sort order.
+  const bestRoomByTrackId = new Map<string | null, string>()
+  for (const t of values) {
+    const existing = bestRoomByTrackId.get(t.trackId)
+    if (existing === undefined || roomSortRank(t.roomEn) < roomSortRank(existing)) {
+      bestRoomByTrackId.set(t.trackId, t.roomEn)
+    }
+  }
+
+  // Pinned rows are ordered by pin order (newest last); unpinned sort by room.
   const pinOrder = new Map((pinnedKeys.value ?? []).map((key, index) => [key, index]))
-  return [...byKey.values()]
-    .sort((a, b) => compareRooms(a.room, b.room) || a.order - b.order)
-    .map((track, index) => ({ ...track, color: TRACK_COLORS[index % TRACK_COLORS.length]! }))
+  return values
+    .sort((a, b) => {
+      const bestA = bestRoomByTrackId.get(a.trackId) ?? ''
+      const bestB = bestRoomByTrackId.get(b.trackId) ?? ''
+      return compareRooms(bestA, bestB) || compareRooms(a.roomEn, b.roomEn)
+    })
+    .map((track) => ({ ...track, color: colorByOrder.get(track.order)! }))
     .sort((a, b) => {
       const ai = pinOrder.get(a.key)
       const bi = pinOrder.get(b.key)
@@ -134,7 +159,11 @@ const tracks = computed(() => {
 // Default main-track key, derived event-wide so the first-visit pin doesn't depend on which day loaded.
 const defaultMainKey = computed(() => {
   const main = (_sessions ?? []).find((session) => isMainTrack(session.track?.name))
-  return main?.track?.id != null ? String(main.track.id) : null
+  if (main?.track?.id == null) {
+    return null
+  }
+  const roomEn = main.room?.en ?? ''
+  return `${String(main.track.id)}__${roomEn}`
 })
 
 // On first visit, pin the main track by default.
@@ -206,7 +235,9 @@ const sessions = computed(() =>
   daySessions.value.map((session) => {
     const startMins = parseMinutes(session.start!)
     const endMins = parseMinutes(session.end!)
-    const key = session.track?.id != null ? String(session.track.id) : NO_TRACK
+    const trackId = session.track?.id != null ? String(session.track.id) : NO_TRACK
+    const roomEn = session.room?.en ?? ''
+    const key = `${trackId}__${roomEn}`
     const index = trackIndex.value.get(key) ?? 0
     // Past / in-progress sessions render dimmed (State A); future sessions render bright (State B).
     // Judge by Taipei date/time so a finished day stays dimmed even when the now line is out of range.
@@ -307,7 +338,16 @@ const HEADER_HEIGHT = 47
     >
       <div class="flex flex-1 flex-col min-w-0">
         <div class="flex gap-1.5 items-center">
+          <NuxtLink
+            v-if="track.trackId !== null"
+            class="text-[14px] leading-[17.5px] font-semibold whitespace-nowrap truncate hover:underline"
+            :class="isPinned(track.key) ? 'text-[#1447e6]' : 'text-[#1a1a1a]'"
+            :to="localePath(`/track/${track.trackId}`)"
+          >
+            {{ track.name }}
+          </NuxtLink>
           <span
+            v-else
             class="text-[14px] leading-[17.5px] font-semibold whitespace-nowrap truncate"
             :class="isPinned(track.key) ? 'text-[#1447e6]' : 'text-[#1a1a1a]'"
           >{{ track.name }}</span>

--- a/app/components/feature/CpSessionTrackTable.vue
+++ b/app/components/feature/CpSessionTrackTable.vue
@@ -365,11 +365,11 @@ const HEADER_HEIGHT = 47
       </div>
       <div class="flex gap-1 items-center">
         <button
-          :aria-label="isPinned(track.roomEn) ? t('unpinTrack') : t('pinTrack')"
+          :aria-label="isPinned(track.roomEn) ? t('unpinRoom') : t('pinRoom')"
           :aria-pressed="isPinned(track.roomEn)"
           class="p-1.5 rounded-[4px] flex cursor-pointer items-center"
           :class="isPinned(track.roomEn) ? 'bg-[#dbeafe] text-[#1447e6]' : 'text-[#99a1af]'"
-          :title="isPinned(track.roomEn) ? t('unpinTrack') : t('pinTrack')"
+          :title="isPinned(track.roomEn) ? t('unpinRoom') : t('pinRoom')"
           type="button"
           @click="togglePin(track.roomEn)"
         >
@@ -481,15 +481,15 @@ const HEADER_HEIGHT = 47
   en:
     other: 'Other'
     trackColumn: 'Track'
-    pinTrack: 'Pin track'
-    unpinTrack: 'Unpin track'
+    pinRoom: 'Pin room'
+    unpinRoom: 'Unpin room'
     add: 'Add to favorites'
     remove: 'Remove from favorites'
   zh:
     other: '其他'
     trackColumn: '議程軌'
-    pinTrack: '釘選議程軌'
-    unpinTrack: '取消釘選'
+    pinRoom: '釘選教室'
+    unpinRoom: '取消釘選'
     add: '加入收藏'
     remove: '取消收藏'
 </i18n>

--- a/app/components/feature/CpSessionTrackTable.vue
+++ b/app/components/feature/CpSessionTrackTable.vue
@@ -21,7 +21,7 @@ const { t, locale } = useI18n()
 const { time } = useRealtime()
 const localePath = useLocalePath()
 const { isFavorite, toggleFavorite } = useFavorites()
-const favoriteLabel = useFavoriteLabel()
+const favoriteLabel = useFavoriteLabel(t)
 
 const { containerRef, isDragging } = useDragScroll({ scrollTarget: 'window' })
 

--- a/app/components/feature/CpSessionTrackTable.vue
+++ b/app/components/feature/CpSessionTrackTable.vue
@@ -86,18 +86,18 @@ function isMainTrack(name?: SessionTrack['name']) {
   return MAIN_TRACK_NAMES.includes(name?.['zh-hant'] ?? '') || MAIN_TRACK_NAMES.includes(name?.en ?? '')
 }
 
+// Shared with CpSessionTable: both pin by English room code so switching views keeps pins in sync.
 // null = never visited (pin main by default); [] = user unpinned everything (respect it).
-// Explicit JSON serializer: a null default otherwise picks the String()-based `any` serializer.
-const pinnedKeys = useLocalStorage<string[] | null>('coscup-pinned-tracks', null, {
+const pinnedRooms = useLocalStorage<string[] | null>('coscup-pinned-rooms', null, {
   serializer: StorageSerializers.object,
 })
-const isPinned = (key: string) => (pinnedKeys.value ?? []).includes(key)
+const isPinned = (roomEn: string) => (pinnedRooms.value ?? []).includes(roomEn)
 
-function togglePin(key: string) {
-  const current = pinnedKeys.value ?? []
-  pinnedKeys.value = current.includes(key)
-    ? current.filter((k) => k !== key)
-    : [...current, key]
+function togglePin(roomEn: string) {
+  const current = pinnedRooms.value ?? []
+  pinnedRooms.value = current.includes(roomEn)
+    ? current.filter((r) => r !== roomEn)
+    : [...current, roomEn]
 }
 
 const tracks = computed(() => {
@@ -137,8 +137,9 @@ const tracks = computed(() => {
     }
   }
 
-  // Pinned rows are ordered by pin order (newest last); unpinned sort by room.
-  const pinOrder = new Map((pinnedKeys.value ?? []).map((key, index) => [key, index]))
+  // Pinned rows float to front (in pin order); unpinned sort by room.
+  // Pin key is roomEn, shared with CpSessionTable.
+  const pinOrder = new Map((pinnedRooms.value ?? []).map((roomEn, index) => [roomEn, index]))
   return values
     .sort((a, b) => {
       const bestA = bestRoomByTrackId.get(a.trackId) ?? ''
@@ -147,8 +148,8 @@ const tracks = computed(() => {
     })
     .map((track) => ({ ...track, color: colorByOrder.get(track.order)! }))
     .sort((a, b) => {
-      const ai = pinOrder.get(a.key)
-      const bi = pinOrder.get(b.key)
+      const ai = pinOrder.get(a.roomEn)
+      const bi = pinOrder.get(b.roomEn)
       if (ai != null && bi != null) {
         return ai - bi
       }
@@ -156,20 +157,16 @@ const tracks = computed(() => {
     })
 })
 
-// Default main-track key, derived event-wide so the first-visit pin doesn't depend on which day loaded.
-const defaultMainKey = computed(() => {
-  const main = (_sessions ?? []).find((session) => isMainTrack(session.track?.name))
-  if (main?.track?.id == null) {
-    return null
-  }
-  const roomEn = main.room?.en ?? ''
-  return `${String(main.track.id)}__${roomEn}`
+// Default main-track room, derived event-wide so the first-visit pin doesn't depend on which day loaded.
+const defaultMainRoom = computed(() => {
+  const main = (_sessions ?? []).find((session) => isMainTrack(session.track?.name) && session.room?.en)
+  return main?.room?.en ?? null
 })
 
-// On first visit, pin the main track by default.
-watch(defaultMainKey, (key) => {
-  if (pinnedKeys.value === null && key != null) {
-    pinnedKeys.value = [key]
+// On first visit, pin the main track's room by default.
+watch(defaultMainRoom, (roomEn) => {
+  if (pinnedRooms.value === null && roomEn != null) {
+    pinnedRooms.value = [roomEn]
   }
 }, { immediate: true })
 
@@ -330,7 +327,7 @@ const HEADER_HEIGHT = 47
       v-for="(track, i) in tracks"
       :key="track.key"
       class="border-b border-r border-b-[rgba(26,26,26,0.06)] flex gap-3 cursor-default items-center left-0 sticky z-dropdown"
-      :class="isPinned(track.key)
+      :class="isPinned(track.roomEn)
         ? 'border-r-[#bedbff] bg-[#eff6ff] shadow-[inset_4px_0px_0px_0px_#3b82f6]'
         : 'border-r-[rgba(26,26,26,0.12)] bg-white'"
       :style="{ 'grid-row': i + 2, 'grid-column': 1, 'padding': '12px 17px 12px 16px' }"
@@ -341,7 +338,7 @@ const HEADER_HEIGHT = 47
           <NuxtLink
             v-if="track.trackId !== null"
             class="text-[14px] leading-[17.5px] font-semibold whitespace-nowrap truncate hover:underline"
-            :class="isPinned(track.key) ? 'text-[#1447e6]' : 'text-[#1a1a1a]'"
+            :class="isPinned(track.roomEn) ? 'text-[#1447e6]' : 'text-[#1a1a1a]'"
             :to="localePath(`/track/${track.trackId}`)"
           >
             {{ track.name }}
@@ -349,13 +346,13 @@ const HEADER_HEIGHT = 47
           <span
             v-else
             class="text-[14px] leading-[17.5px] font-semibold whitespace-nowrap truncate"
-            :class="isPinned(track.key) ? 'text-[#1447e6]' : 'text-[#1a1a1a]'"
+            :class="isPinned(track.roomEn) ? 'text-[#1447e6]' : 'text-[#1a1a1a]'"
           >{{ track.name }}</span>
         </div>
         <div
           v-if="track.room"
           class="pt-1 flex gap-0.5 items-center"
-          :class="isPinned(track.key) ? 'text-[#2b7fff]' : 'text-[#737373]'"
+          :class="isPinned(track.roomEn) ? 'text-[#2b7fff]' : 'text-[#737373]'"
         >
           <Icon
             class="text-[12px] shrink-0"
@@ -368,17 +365,17 @@ const HEADER_HEIGHT = 47
       </div>
       <div class="flex gap-1 items-center">
         <button
-          :aria-label="isPinned(track.key) ? t('unpinTrack') : t('pinTrack')"
-          :aria-pressed="isPinned(track.key)"
+          :aria-label="isPinned(track.roomEn) ? t('unpinTrack') : t('pinTrack')"
+          :aria-pressed="isPinned(track.roomEn)"
           class="p-1.5 rounded-[4px] flex cursor-pointer items-center"
-          :class="isPinned(track.key) ? 'bg-[#dbeafe] text-[#1447e6]' : 'text-[#99a1af]'"
-          :title="isPinned(track.key) ? t('unpinTrack') : t('pinTrack')"
+          :class="isPinned(track.roomEn) ? 'bg-[#dbeafe] text-[#1447e6]' : 'text-[#99a1af]'"
+          :title="isPinned(track.roomEn) ? t('unpinTrack') : t('pinTrack')"
           type="button"
-          @click="togglePin(track.key)"
+          @click="togglePin(track.roomEn)"
         >
           <Icon
             class="text-[14px]"
-            :name="isPinned(track.key) ? 'tabler:pin-filled' : 'tabler:pin'"
+            :name="isPinned(track.roomEn) ? 'tabler:pin-filled' : 'tabler:pin'"
           />
         </button>
         <span class="p-1 rounded-[4px] flex items-center">

--- a/app/components/feature/CpSessionTrackTable.vue
+++ b/app/components/feature/CpSessionTrackTable.vue
@@ -3,21 +3,25 @@ import type { SessionSummary, SessionTrack } from '#shared/types/session'
 import { StorageSerializers, useLocalStorage } from '@vueuse/core'
 import { useI18n } from 'vue-i18n'
 import { useDragScroll } from '~/composables/useDragScroll'
+import { useFavoriteLabel, useFavorites } from '~/composables/useFavorites'
 import { useRealtime } from '~/composables/useRealtime'
 import { TRACK_COLORS } from '~/utils/tracks'
 
-const { sessions: _sessions, day, timeRange, interval, rowHeight, columnWidth } = defineProps<{
+const { sessions: _sessions, day, timeRange, interval, rowHeight, columnWidth, preview = false } = defineProps<{
   day: string
   timeRange: [string, string]
   sessions: SessionSummary[]
   interval: number
   rowHeight: number
   columnWidth: number
+  preview?: boolean
 }>()
 
 const { t, locale } = useI18n()
 const { time } = useRealtime()
 const localePath = useLocalePath()
+const { isFavorite, toggleFavorite } = useFavorites()
+const favoriteLabel = useFavoriteLabel()
 
 const { containerRef, isDragging } = useDragScroll({ scrollTarget: 'window' })
 
@@ -347,17 +351,14 @@ const HEADER_HEIGHT = 47
     </div>
 
     <!-- Session cards -->
-    <NuxtLink
+    <div
       v-for="session in sessions"
       :key="session.id"
       class="flex items-stretch overflow-hidden"
-      :draggable="false"
       :style="{
         'grid-row': session.row,
         'grid-column': `${session.col[0]} / ${session.col[1]}`,
       }"
-      :to="localePath(`/session/${session.id}`)"
-      @dragstart.prevent
     >
       <div
         class="border border-black/10 flex flex-1 flex-col h-16 self-center box-border relative overflow-hidden"
@@ -372,20 +373,19 @@ const HEADER_HEIGHT = 47
           class="bg-black/30 pointer-events-none inset-0 absolute"
         />
 
+        <!-- Overlay link: covers the card; star button renders on top as a sibling. -->
+        <NuxtLink
+          :aria-label="session.title"
+          class="inset-0 absolute"
+          :draggable="false"
+          :to="localePath(`/session/${session.id}`)"
+          @dragstart.prevent
+        />
+
         <!-- Content -->
         <div
-          class="px-2 py-1.5 flex flex-1 flex-col w-full items-start justify-center relative overflow-clip"
+          class="px-2 py-1.5 flex flex-1 flex-col w-full pointer-events-none items-start justify-center relative overflow-clip"
         >
-          <!-- Favorite star (static visual element) -->
-          <span
-            class="p-1 rounded-[4px] bg-black/10 flex items-center left-1 top-1 absolute"
-          >
-            <Icon
-              class="text-[12px] text-white"
-              name="tabler:star"
-            />
-          </span>
-
           <h3
             class="text-[12px] text-white leading-[15px] font-semibold pl-5 whitespace-nowrap"
             :class="{ 'w-full overflow-hidden text-ellipsis': session.isPast }"
@@ -402,8 +402,23 @@ const HEADER_HEIGHT = 47
             class="text-[9px] text-white leading-[13.5px] font-mono pt-0.5 opacity-80 whitespace-nowrap"
           >{{ session.start }}-{{ session.end }}</time>
         </div>
+
+        <!-- Favorite star: sibling after NuxtLink so it renders on top. -->
+        <button
+          :aria-label="favoriteLabel(session.id, preview)"
+          :aria-pressed="preview || isFavorite(session.id)"
+          class="p-1 rounded-[4px] bg-black/10 flex cursor-pointer items-center left-1 top-1 absolute"
+          type="button"
+          @click.prevent.stop="!preview && toggleFavorite(session.id)"
+          @pointerdown.stop
+        >
+          <Icon
+            class="text-[12px] text-white"
+            :name="preview || isFavorite(session.id) ? 'tabler:star-filled' : 'tabler:star'"
+          />
+        </button>
       </div>
-    </NuxtLink>
+    </div>
 
     <!-- Current-time ("now") line -->
     <ClientOnly>
@@ -431,9 +446,13 @@ const HEADER_HEIGHT = 47
     trackColumn: 'Track'
     pinTrack: 'Pin track'
     unpinTrack: 'Unpin track'
+    add: 'Add to favorites'
+    remove: 'Remove from favorites'
   zh:
     other: '其他'
     trackColumn: '議程軌'
     pinTrack: '釘選議程軌'
     unpinTrack: '取消釘選'
+    add: '加入收藏'
+    remove: '取消收藏'
 </i18n>

--- a/app/composables/useFavorites.ts
+++ b/app/composables/useFavorites.ts
@@ -79,10 +79,13 @@ export function useFavorites(): FavoritesStore {
  * The bookmark `aria-label` for a session, resolved by the parent list so the
  * per-card `CpSessionItem` stays free of an i18n scope (hundreds of cards would
  * otherwise OOM the prerender). Shared by both the table and list layouts.
+ *
+ * The caller must pass its own `t` so the keys (`add`, `remove`) live in the
+ * component's `<i18n>` block instead of inside this composable. This avoids the
+ * "Duplicate useI18n calling by local scope" warning that occurs when a composable
+ * creates its own local composer while the component already has one.
  */
-export function useFavoriteLabel(): (id: string, preview?: boolean) => string {
+export function useFavoriteLabel(t: (key: string) => string): (id: string, preview?: boolean) => string {
   const { isFavorite } = useFavorites()
-  const { t } = useI18n({ useScope: 'local' })
-
   return (id, preview = false) => (preview || isFavorite(id)) ? t('remove') : t('add')
 }

--- a/app/composables/useFavorites.ts
+++ b/app/composables/useFavorites.ts
@@ -82,13 +82,7 @@ export function useFavorites(): FavoritesStore {
  */
 export function useFavoriteLabel(): (id: string, preview?: boolean) => string {
   const { isFavorite } = useFavorites()
-  const { t } = useI18n({
-    useScope: 'local',
-    messages: {
-      en: { add: 'Add to favorites', remove: 'Remove from favorites' },
-      zh: { add: '加入收藏', remove: '取消收藏' },
-    },
-  })
+  const { t } = useI18n({ useScope: 'local' })
 
   return (id, preview = false) => (preview || isFavorite(id)) ? t('remove') : t('add')
 }

--- a/app/pages/session.vue
+++ b/app/pages/session.vue
@@ -210,9 +210,7 @@ definePageMeta({
             :days="days"
           />
 
-          <!-- Hidden while previewing a shared list. -->
           <CpSessionFilterBar
-            v-if="!isSharing"
             v-model:search-query="searchQuery"
             v-model:selected-tag-ids="selectedTagIds"
             v-model:view-mode="viewMode"

--- a/app/pages/session.vue
+++ b/app/pages/session.vue
@@ -243,6 +243,7 @@ definePageMeta({
             :column-width="20"
             :day="selectedDay"
             :interval="5"
+            :preview="isSharing"
             :row-height="80"
             :sessions="displayedSessions"
             :time-range="['09:00', '17:30']"

--- a/app/pages/session.vue
+++ b/app/pages/session.vue
@@ -253,7 +253,7 @@ definePageMeta({
             :day="selectedDay"
             :interval="5"
             :preview="isSharing"
-            :row-height="10"
+            :row-height="20"
             :sessions="displayedSessions"
             :time-range="['09:00', '17:30']"
           />


### PR DESCRIPTION
## 變更摘要

- 在 `CpSessionTrackTable` 加入收藏（書籤）功能——書籤按鈕採用 overlay-link 模式（NuxtLink 作為 `absolute inset-0` 兄弟元素，星號按鈕在 DOM 後方覆蓋其上），並加上 `@pointerdown.stop` 防止觸發拖曳捲動
- 新增 `preview` prop，在預覽分享連結時隱藏收藏互動
- 在議程篩選列加入檢視模式切換（依議程軌 / 依教室），取代原本的教室篩選下拉選單
- 同一議程軌若橫跨多間教室，拆分為多列顯示；複合鍵 `${trackId}__${roomEn}` 讓每個議程軌+教室組合各有獨立列
- 同一議程軌的所有列共用同一顏色（依 track order 分配，非列索引）
- 依教室優先級排序；跨教室的議程軌，以最高優先級教室決定該組在整體列表中的位置
- 議程軌名稱改為可點擊的 `NuxtLink`，導向 `/track/:id`
- 「依教室」與「依議程軌」兩個檢視共用釘選狀態——均讀寫 `coscup-pinned-rooms`（英文教室代碼），切換檢視時釘選狀態保持同步
- 修正 `useFavoriteLabel` i18n 問題：移除 composable 內的 `useScope: 'local'`（原因：造成「Duplicate useI18n calling by local scope」警告）；改由呼叫端傳入自己的 `t`，翻譯 key（`add`、`remove`）定義在各元件的 `<i18n>` block 中

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved track pinning by room, preserving pin order and prioritizing the main track on first visit.
  * Added shared preview behavior for session track tables.
  * Favorite buttons now remain accessible and interactive within session cards.
* **Bug Fixes**
  * Improved localized accessibility labels for adding and removing favorites in English and Chinese.
  * Corrected favorite label handling across session lists and tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->