### PR TITLE
使得議程表旁邊的議程主題可以點選，並在主題頁面可以回到議程表

### DIFF
--- a/app/components/feature/CpSessionTable.vue
+++ b/app/components/feature/CpSessionTable.vue
@@ -100,19 +100,20 @@ const trackColors = computed(() =>
   buildTrackColorMap((_sessions ?? []).filter((session) => session.start?.startsWith(day) && session.end)),
 )
 
-// Rooms are the columns. Each carries the track name(s) hosted there as a subtitle.
+// Rooms are the columns. Each carries the track(s) hosted there as subtitle links.
 const roomsRaw = computed(() => {
-  const byCode = new Map<string, { code: string, trackNames: Set<string>, isMain: boolean }>()
+  const byCode = new Map<string, { code: string, tracks: Map<string, string | null>, isMain: boolean }>()
   for (const session of daySessions.value) {
     const code = session.room!.en
     let info = byCode.get(code)
     if (!info) {
-      info = { code, trackNames: new Set(), isMain: false }
+      info = { code, tracks: new Map(), isMain: false }
       byCode.set(code, info)
     }
     const name = localeName(session.track?.name)
-    if (name) {
-      info.trackNames.add(name)
+    const trackId = session.track?.id != null ? String(session.track.id) : null
+    if (name && !info.tracks.has(name)) {
+      info.tracks.set(name, trackId)
     }
     if (isMainTrack(session.track?.name)) {
       info.isMain = true
@@ -120,7 +121,7 @@ const roomsRaw = computed(() => {
   }
   return [...byCode.values()].map((room) => ({
     code: room.code,
-    subtitle: [...room.trackNames].join('、'),
+    trackLinks: [...room.tracks.entries()].map(([name, id]) => ({ name, id })),
     isMain: room.isMain,
   }))
 })
@@ -310,10 +311,23 @@ const sessions = computed(() =>
         </button>
       </div>
       <p
-        v-if="room.subtitle"
+        v-if="room.trackLinks.length"
         class="text-[10px] text-[#737373] leading-[15px] pt-[2px] w-full whitespace-nowrap relative overflow-hidden"
       >
-        {{ room.subtitle }}
+        <template
+          v-for="(link, n) in room.trackLinks"
+          :key="link.name"
+        >
+          <NuxtLink
+            v-if="link.id"
+            class="hover:underline"
+            :to="localePath(`/track/${link.id}`)"
+          >
+            {{ link.name }}
+          </NuxtLink>
+          <span v-else>{{ link.name }}</span>
+          <span v-if="n < room.trackLinks.length - 1">、</span>
+        </template>
       </p>
     </div>
 

--- a/app/pages/track/[id].vue
+++ b/app/pages/track/[id].vue
@@ -110,7 +110,7 @@ useSeoMeta({
   >
     <NuxtLink
       class="text-sm text-gray-500 inline-flex gap-1.5 w-fit transition-colors items-center hover:text-primary-500"
-      :to="localePath('/track')"
+      :to="localePath('/session')"
     >
       <Icon
         class="h-4 w-4"
@@ -187,12 +187,12 @@ useSeoMeta({
 
 <i18n lang="yaml">
   en:
-    back: 'Back to tracks'
+    back: 'Back to sessions'
     day: 'Day {n}'
     notFound: 'Track not found.'
     separator: ', '
   zh:
-    back: '返回議程軌列表'
+    back: '返回議程'
     day: '第 {n} 天'
     notFound: '找不到這個議程軌。'
     separator: '、'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Room headers now display multiple associated tracks, showing linked track details when an ID is available.
* **Bug Fixes**
  * Updated the track details page “back” navigation to return to the sessions page, with matching i18n label updates.
  * Preserves existing query parameters when navigating to track pages from session track tables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->