### PR TITLE
feat: update session popup

### DIFF
--- a/app/components/feature/CpSessionInfoCard.vue
+++ b/app/components/feature/CpSessionInfoCard.vue
@@ -16,12 +16,20 @@ const props = defineProps<{
   room: string
   coWrite?: string
   tags: string[]
+  track?: {
+    id: number
+    name: string
+    color: string
+  }
   description: string
   ad: Ad | null
+  hasTitleMarginRight?: boolean
 }>()
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
+const isZh = computed(() => locale.value === 'zh')
 const isMobile = useMediaQuery('(max-width: 639px)')
+const localePath = useLocalePath()
 
 const speakerNames = computed(() =>
   props.speakers.map((s) => s.name).join(', '),
@@ -29,57 +37,72 @@ const speakerNames = computed(() =>
 </script>
 
 <template>
-  <article class="bg-white flex flex-col gap-3 min-w-0 sm:p-6">
-    <header>
-      <h1 class="text-xl text-primary-400 leading-tight font-bold mb-4 break-words sm:text-2xl">
+  <article class="py-5 bg-white flex flex-col gap-3 min-w-0">
+    <header class="px-4 sm:px-6">
+      <h1
+        class="text-xl leading-tight font-bold mb-4 break-words sm:text-2xl"
+        :class="hasTitleMarginRight ? 'mr-24 sm:mr-34' : ''"
+      >
         {{ title }}
       </h1>
-      <dl class="flex flex-col gap-3">
-        <div class="gap-1 grid sm:gap-4 sm:grid-cols-[7rem_minmax(0,1fr)]">
-          <dt class="text-sm text-gray-400 flex gap-1.5 items-center">
+      <dl class="mb-3 flex flex-col gap-2">
+        <div
+          class="gap-4 grid"
+          :class="isZh ? 'grid-cols-[auto_minmax(0,1fr)]' : 'grid-cols-[6rem_minmax(0,1fr)]'"
+        >
+          <dt class="text-sm text-neutral-500 flex gap-1.5 items-center">
             <Icon
               class="shrink-0 h-4 w-4"
               name="tabler:clock"
             />
             {{ t("time") }}
           </dt>
-          <dd class="text-gray-700 ml-5 min-w-0 break-words sm:ml-0">
+          <dd class="text-zinc-900 min-w-0 break-words">
             {{ time }}
           </dd>
         </div>
-        <div class="gap-1 grid sm:gap-4 sm:grid-cols-[7rem_minmax(0,1fr)]">
-          <dt class="text-sm text-gray-400 flex gap-1.5 items-center">
+        <div
+          class="gap-4 grid"
+          :class="isZh ? 'grid-cols-[auto_minmax(0,1fr)]' : 'grid-cols-[6rem_minmax(0,1fr)]'"
+        >
+          <dt class="text-sm text-neutral-500 flex gap-1.5 items-center">
             <Icon
               class="shrink-0 h-4 w-4"
               name="tabler:user"
             />
             {{ t("speaker") }}
           </dt>
-          <dd class="text-gray-700 ml-5 min-w-0 break-words sm:ml-0">
+          <dd class="text-zinc-900 min-w-0 break-words">
             {{ speakerNames }}
           </dd>
         </div>
-        <div class="gap-1 grid sm:gap-4 sm:grid-cols-[7rem_minmax(0,1fr)]">
-          <dt class="text-sm text-gray-400 flex gap-1.5 items-center">
+        <div
+          class="gap-4 grid"
+          :class="isZh ? 'grid-cols-[auto_minmax(0,1fr)]' : 'grid-cols-[6rem_minmax(0,1fr)]'"
+        >
+          <dt class="text-sm text-neutral-500 flex gap-1.5 items-center">
             <Icon
               class="shrink-0 h-4 w-4"
               name="tabler:map-pin"
             />
             {{ t("room") }}
           </dt>
-          <dd class="text-gray-700 ml-5 min-w-0 break-words sm:ml-0">
+          <dd class="text-zinc-900 min-w-0 break-words">
             {{ room }}
           </dd>
         </div>
-        <div class="gap-1 grid sm:gap-4 sm:grid-cols-[7rem_minmax(0,1fr)]">
-          <dt class="text-sm text-gray-400 flex gap-1.5 items-center">
+        <div
+          class="gap-4 grid"
+          :class="isZh ? 'grid-cols-[auto_minmax(0,1fr)]' : 'grid-cols-[6rem_minmax(0,1fr)]'"
+        >
+          <dt class="text-sm text-neutral-500 flex gap-1.5 items-center">
             <Icon
               class="shrink-0 h-4 w-4"
               name="tabler:file-text"
             />
             {{ t("co-write") }}
           </dt>
-          <dd class="text-gray-700 ml-5 min-w-0 break-words sm:ml-0">
+          <dd class="text-zinc-900 min-w-0 break-words">
             <a
               v-if="coWrite?.startsWith('http')"
               class="underline cursor-pointer break-all"
@@ -90,19 +113,32 @@ const speakerNames = computed(() =>
         </div>
       </dl>
       <div
-        class="mt-5 pb-3 border-b border-gray-200 flex flex-wrap gap-2"
+        class="flex flex-wrap gap-2"
       >
+        <NuxtLink
+          v-if="track"
+          class="text-xs text-white font-medium px-3 py-1 rounded-full underline-offset-2 flex gap-0.5 items-center hover:underline"
+          :style="{ backgroundColor: track.color }"
+          :to="localePath(`/track/${track.id}`)"
+        >
+          {{ track.name }}
+          <Icon
+            class="h-4 w-4"
+            name="tabler:arrow-up-right"
+          />
+        </NuxtLink>
         <span
           v-for="tag in tags"
           :key="tag"
-          class="text-xs text-primary-700 font-medium px-3 py-1 rounded-full bg-primary-100"
+          class="text-xs text-zinc-900 font-medium px-3 py-1 rounded-full bg-stone-100"
         >
           {{ tag }}
         </span>
       </div>
     </header>
-    <section>
-      <h2 class="text-lg text-primary-400 font-bold my-3">
+    <div class="border-b border-gray-200" />
+    <section class="px-4 sm:px-6">
+      <h2 class="text-lg font-bold my-2">
         {{ t("abstract") }}
       </h2>
       <div
@@ -111,35 +147,19 @@ const speakerNames = computed(() =>
         <MDC :value="description" />
       </div>
     </section>
-    <section
-      v-if="ad && isMobile"
-      class="w-full aspect-[18/5]"
-    >
-      <NuxtLink
-        class="h-full w-full block"
-        target="_blank"
-        :to="ad.link"
-      >
-        <NuxtImg
-          :alt="ad.id"
-          class="h-full w-full object-contain"
-          :src="ad.imageHorizontal"
-        />
-      </NuxtLink>
-    </section>
-    <section>
-      <h2 class="text-lg text-primary-400 font-bold my-2">
+    <section class="px-4 sm:px-6">
+      <h2 class="text-lg font-bold my-2">
         {{ t("speaker") }}
       </h2>
-      <div class="flex flex-col gap-6">
+      <div class="flex flex-col gap-4">
         <div
           v-for="speaker in speakers"
           :key="speaker.name"
-          class="flex flex-col gap-4"
+          class="p-4 rounded bg-gray-50 flex flex-col gap-4"
         >
-          <div class="flex gap-4 items-center">
+          <div class="flex gap-4">
             <div
-              class="border-2 border-primary-100 rounded-full bg-gray-100 flex-shrink-0 h-16 w-16 overflow-hidden"
+              class="border-2 border-gray-100 rounded-full bg-gray-100 flex-shrink-0 h-16 w-16 top-3 sticky overflow-hidden"
             >
               <img
                 v-if="speaker.avatar"
@@ -158,18 +178,36 @@ const speakerNames = computed(() =>
               </div>
             </div>
             <div>
-              <h3 class="text-lg text-gray-700 font-bold">
-                {{ speaker.name }}
-              </h3>
+              <div>
+                <h3 class="text-lg text-gray-700 font-bold">
+                  {{ speaker.name }}
+                </h3>
+              </div>
+              <div
+                class="text-sm text-gray-700 leading-relaxed whitespace-pre-wrap break-words"
+              >
+                <MDC :value="speaker.bio" />
+              </div>
             </div>
-          </div>
-          <div
-            class="text-sm text-gray-700 leading-relaxed whitespace-pre-wrap break-words"
-          >
-            <MDC :value="speaker.bio" />
           </div>
         </div>
       </div>
+    </section>
+    <section
+      v-if="ad && isMobile"
+      class="px-4 w-full aspect-[18/5]"
+    >
+      <NuxtLink
+        class="h-full w-full block"
+        target="_blank"
+        :to="ad.link"
+      >
+        <NuxtImg
+          :alt="ad.id"
+          class="h-full w-full object-contain"
+          :src="ad.imageHorizontal"
+        />
+      </NuxtLink>
     </section>
   </article>
 </template>
@@ -182,7 +220,7 @@ en:
     speaker: Speaker
     time: time
 zh:
-    abstract: 摘要
+    abstract: 議程簡介
     room: 位置
     speaker: 講者
     time: 時間

--- a/app/components/feature/CpSessionTable.vue
+++ b/app/components/feature/CpSessionTable.vue
@@ -5,12 +5,13 @@ import { useI18n } from '#imports'
 import { useDragScroll } from '~/composables/useDragScroll'
 import { useFavoriteLabel, useFavorites } from '~/composables/useFavorites'
 import { useRealtime } from '~/composables/useRealtime'
-import { buildTrackColorMap, isMainTrack, trackKey } from '~/utils/tracks'
+import { isMainTrack, trackKey } from '~/utils/tracks'
 
-const { sessions: _sessions, day, timeRange, interval, rowHeight, columnWidth, preview = false } = defineProps<{
+const { sessions: _sessions, trackColors, day, timeRange, interval, rowHeight, columnWidth, preview = false } = defineProps<{
   day: string
   timeRange: [string, string]
   sessions: SessionSummary[]
+  trackColors: Map<string, string>
   interval: number
   rowHeight: number
   columnWidth: number
@@ -94,13 +95,7 @@ const daySessions = computed(() =>
   ),
 )
 
-// A track keeps its colour across both table views (see ~/utils/tracks). Build from the whole
-// day (not just roomed sessions) so the index order matches CpSessionTrackTable exactly.
-const trackColors = computed(() =>
-  buildTrackColorMap((_sessions ?? []).filter((session) => session.start?.startsWith(day) && session.end)),
-)
-
-// Rooms are the columns. Each carries the track(s) hosted there as subtitle links.
+// Rooms are the columns. Each carries the track name(s) hosted there as a subtitle.
 const roomsRaw = computed(() => {
   const byCode = new Map<string, { code: string, tracks: Map<string, string | null>, isMain: boolean }>()
   for (const session of daySessions.value) {
@@ -246,7 +241,7 @@ const sessions = computed(() =>
       tag: difficultyLabel(session.tags),
       row: [toRow(startMins), toRow(endMins)],
       col: rooms.value.findIndex((r) => r.code === session.room!.en) + 2,
-      color: trackColors.value.get(trackKey(session)) ?? '#e76f51',
+      color: trackColors.get(trackKey(session)) ?? '#e76f51',
       isPast,
     }
   }),

--- a/app/components/feature/CpSessionTable.vue
+++ b/app/components/feature/CpSessionTable.vue
@@ -5,7 +5,7 @@ import { useI18n } from '#imports'
 import { useDragScroll } from '~/composables/useDragScroll'
 import { useFavoriteLabel, useFavorites } from '~/composables/useFavorites'
 import { useRealtime } from '~/composables/useRealtime'
-import { isMainTrack, trackKey } from '~/utils/tracks'
+import { DEFAULT_TRACK_COLOR, isMainTrack, trackKey } from '~/utils/tracks'
 
 const { sessions: _sessions, trackColors, day, timeRange, interval, rowHeight, columnWidth, preview = false } = defineProps<{
   day: string
@@ -241,7 +241,7 @@ const sessions = computed(() =>
       tag: difficultyLabel(session.tags),
       row: [toRow(startMins), toRow(endMins)],
       col: rooms.value.findIndex((r) => r.code === session.room!.en) + 2,
-      color: trackColors.get(trackKey(session)) ?? '#e76f51',
+      color: trackColors.get(trackKey(session)) ?? DEFAULT_TRACK_COLOR,
       isPast,
     }
   }),

--- a/app/components/feature/CpSessionTrackTable.vue
+++ b/app/components/feature/CpSessionTrackTable.vue
@@ -5,12 +5,13 @@ import { useI18n } from 'vue-i18n'
 import { useDragScroll } from '~/composables/useDragScroll'
 import { useFavoriteLabel, useFavorites } from '~/composables/useFavorites'
 import { useRealtime } from '~/composables/useRealtime'
-import { TRACK_COLORS } from '~/utils/tracks'
+import { NO_TRACK } from '~/utils/tracks'
 
-const { sessions: _sessions, day, timeRange, interval, rowHeight, columnWidth, preview = false } = defineProps<{
+const { sessions: _sessions, trackColors, day, timeRange, interval, rowHeight, columnWidth, preview = false } = defineProps<{
   day: string
   timeRange: [string, string]
   sessions: SessionSummary[]
+  trackColors: Map<string, string>
   interval: number
   rowHeight: number
   columnWidth: number
@@ -77,9 +78,6 @@ const daySessions = computed(() =>
   (_sessions ?? []).filter((session) => session.start?.startsWith(day) && session.end),
 )
 
-// Rows are tracks. Track-less sessions collapse into one fallback bucket so nothing disappears.
-const NO_TRACK = '__none__'
-
 // Match by name (either locale) since Pretalx track ids aren't stable across events.
 const MAIN_TRACK_NAMES = ['主議程', 'Main Session Track']
 function isMainTrack(name?: SessionTrack['name']) {
@@ -101,7 +99,7 @@ function togglePin(roomEn: string) {
 }
 
 const tracks = computed(() => {
-  const byKey = new Map<string, { key: string, trackId: string | null, order: number, name: string, room: string, roomEn: string, isMain: boolean }>()
+  const byKey = new Map<string, { key: string, trackId: string | null, name: string, room: string, roomEn: string, isMain: boolean }>()
   for (const session of daySessions.value) {
     const id = session.track?.id
     const trackId = id != null ? String(id) : null
@@ -111,7 +109,6 @@ const tracks = computed(() => {
       byKey.set(key, {
         key,
         trackId,
-        order: id ?? Number.POSITIVE_INFINITY,
         name: session.track ? localeName(session.track.name) : t('other'),
         room: localeName(session.room),
         roomEn,
@@ -121,11 +118,6 @@ const tracks = computed(() => {
   }
 
   const values = [...byKey.values()]
-
-  // Assign color by unique track order so same track always gets the same color,
-  // even when split across multiple rooms.
-  const uniqueOrders = [...new Set(values.map((t) => t.order))].sort((a, b) => a - b)
-  const colorByOrder = new Map(uniqueOrders.map((order, i) => [order, TRACK_COLORS[i % TRACK_COLORS.length]!]))
 
   // For tracks spanning multiple rooms, use the highest-priority room in the group
   // to determine the track group's position in the overall sort order.
@@ -146,7 +138,7 @@ const tracks = computed(() => {
       const bestB = bestRoomByTrackId.get(b.trackId) ?? ''
       return compareRooms(bestA, bestB) || compareRooms(a.roomEn, b.roomEn)
     })
-    .map((track) => ({ ...track, color: colorByOrder.get(track.order)! }))
+    .map((track) => ({ ...track, color: trackColors.get(track.trackId ?? NO_TRACK) ?? '#e76f51' }))
     .sort((a, b) => {
       const ai = pinOrder.get(a.roomEn)
       const bi = pinOrder.get(b.roomEn)

--- a/app/components/feature/CpSessionTrackTable.vue
+++ b/app/components/feature/CpSessionTrackTable.vue
@@ -5,7 +5,7 @@ import { useI18n } from 'vue-i18n'
 import { useDragScroll } from '~/composables/useDragScroll'
 import { useFavoriteLabel, useFavorites } from '~/composables/useFavorites'
 import { useRealtime } from '~/composables/useRealtime'
-import { NO_TRACK } from '~/utils/tracks'
+import { DEFAULT_TRACK_COLOR, NO_TRACK } from '~/utils/tracks'
 
 const { sessions: _sessions, trackColors, day, timeRange, interval, rowHeight, columnWidth, preview = false } = defineProps<{
   day: string
@@ -138,7 +138,7 @@ const tracks = computed(() => {
       const bestB = bestRoomByTrackId.get(b.trackId) ?? ''
       return compareRooms(bestA, bestB) || compareRooms(a.roomEn, b.roomEn)
     })
-    .map((track) => ({ ...track, color: trackColors.get(track.trackId ?? NO_TRACK) ?? '#e76f51' }))
+    .map((track) => ({ ...track, color: trackColors.get(track.trackId ?? NO_TRACK) ?? DEFAULT_TRACK_COLOR }))
     .sort((a, b) => {
       const ai = pinOrder.get(a.roomEn)
       const bi = pinOrder.get(b.roomEn)
@@ -242,7 +242,7 @@ const sessions = computed(() =>
       end: session.end!.slice(11, 16).replace(/^0/, ''),
       col: [toCol(startMins), toCol(endMins)],
       row: index + 2,
-      color: tracks.value[index]?.color ?? '#e76f51',
+      color: tracks.value[index]?.color ?? DEFAULT_TRACK_COLOR,
       isPast,
     }
   }),

--- a/app/pages/session.vue
+++ b/app/pages/session.vue
@@ -15,6 +15,7 @@ import CpSessionTrackTable from '~/components/feature/CpSessionTrackTable.vue'
 import CpSessionViewToggle from '~/components/feature/CpSessionViewToggle.vue'
 import { decodeFavorites, provideFavorites } from '~/composables/useFavorites'
 import { useSessionFilter } from '~/composables/useSessionFilter'
+import { buildTrackColorMap } from '~/utils/tracks'
 
 const { locale, t } = useI18n()
 const route = useRoute()
@@ -114,6 +115,8 @@ const displayedSessions = computed(() => {
   }
   return filteredSessions.value
 })
+
+const trackColors = computed(() => buildTrackColorMap(daySessions.value))
 
 const emptyVariant = computed<'filter' | 'favorite' | 'shared'>(() => {
   if (isSharing.value) {
@@ -245,6 +248,7 @@ definePageMeta({
             :row-height="80"
             :sessions="displayedSessions"
             :time-range="['09:00', '17:30']"
+            :track-colors="trackColors"
           />
           <CpSessionTable
             v-if="displayedSessions.length > 0 && viewMode === 'table'"
@@ -256,6 +260,7 @@ definePageMeta({
             :row-height="20"
             :sessions="displayedSessions"
             :time-range="['09:00', '17:30']"
+            :track-colors="trackColors"
           />
 
           <CpSessionEmptyBanner

--- a/app/pages/session/[id].vue
+++ b/app/pages/session/[id].vue
@@ -1,25 +1,51 @@
 <script setup lang="ts">
 import type { Ad } from '#shared/types/ad'
-import type { SessionDetail } from '#shared/types/session'
+import type { SessionDetail, SessionSummary } from '#shared/types/session'
 import { useMediaQuery } from '@vueuse/core'
+import { useI18n } from 'vue-i18n'
 import CpSessionInfoCard from '~/components/feature/CpSessionInfoCard.vue'
+import { useFavorites } from '~/composables/useFavorites'
+import { buildTrackColorMap, trackKey } from '~/utils/tracks'
 
-const { locale } = useI18n()
+const { t, locale } = useI18n()
 const route = useRoute()
 const router = useRouter()
 const localePath = useLocalePath()
 const isDesktop = useMediaQuery('(min-width: 640px)')
+const sessionId = computed(() => String(route.params.id ?? ''))
+const { isFavorite, toggleFavorite } = useFavorites()
+const scroller = ref<HTMLElement | null>(null)
+const dragOffsetY = ref(0)
+const isDragging = ref(false)
+const dragCloseThreshold = 140
+const dragState = {
+  startY: 0,
+}
 
-const { data: sessionDetail, error } = await useFetch<SessionDetail>(`/api/session/${route.params.id}`)
+const { data: sessionDetail, error } = await useFetch<SessionDetail>(`/api/session/${sessionId.value}`)
 if (error.value) {
   throw error.value.statusCode === 404
     ? createError({ status: 404, statusText: 'Page Not Found' })
     : error.value
 }
+const { data: sessionsByDay } = await useFetch<Record<string, SessionSummary[]>>('/api/session')
 const { data: ad } = await useFetch<Ad[]>('/api/ad')
 const randomAd = ref<Ad | null>(null)
 
 const localeKey = computed(() => locale.value === 'zh' ? 'zh' : 'en')
+
+const sessionTrackColor = computed(() => {
+  const session = sessionDetail.value
+  if (!session?.start) {
+    return '#e76f51'
+  }
+
+  const day = session.start.slice(0, 10)
+  const daySessions = sessionsByDay.value?.[day] ?? []
+  const trackColors = buildTrackColorMap(daySessions)
+
+  return trackColors.get(trackKey(session)) ?? '#e76f51'
+})
 
 const sessionInfo = computed(() => {
   if (!sessionDetail.value) {
@@ -30,6 +56,15 @@ const sessionInfo = computed(() => {
   const room = locale.value === 'zh'
     ? (sessionDetail.value.room?.['zh-hant'] || sessionDetail.value.room?.en || '')
     : (sessionDetail.value.room?.en || sessionDetail.value.room?.['zh-hant'] || '')
+  const track = sessionDetail.value.track
+    ? {
+        id: sessionDetail.value.track.id,
+        name: locale.value === 'zh'
+          ? (sessionDetail.value.track?.name?.['zh-hant'] || sessionDetail.value.track?.name?.en || '')
+          : (sessionDetail.value.track?.name?.en || sessionDetail.value.track?.name?.['zh-hant'] || ''),
+        color: sessionTrackColor.value,
+      }
+    : undefined
 
   return {
     coWrite: sessionDetail.value.co_write ?? undefined,
@@ -42,7 +77,8 @@ const sessionInfo = computed(() => {
       name: speaker[localeKey.value].name,
     })),
     tags: sessionDetail.value.tags,
-    time: `${sessionDetail.value.start?.slice(11, 16) ?? ''} ~ ${sessionDetail.value.end?.slice(11, 16) ?? ''}`,
+    track,
+    time: `${sessionDetail.value.start?.slice(0, 16).replace('T', ' ') ?? ''} ~ ${sessionDetail.value.end?.slice(11, 16) ?? ''}`,
     title: content.title,
   }
 })
@@ -58,6 +94,60 @@ useSeoMeta({
 
 function close() {
   router.push(localePath({ path: '/session', query: route.query }))
+}
+
+const sheetStyle = computed(() => ({
+  transform: dragOffsetY.value > 0 ? `translateY(${dragOffsetY.value}px)` : undefined,
+  transition: isDragging.value ? 'none' : undefined,
+}))
+
+function isInteractiveTarget(target: EventTarget | null) {
+  return target instanceof Element && !!target.closest('a, button, input, textarea, select, [role="button"]')
+}
+
+function resetDrag() {
+  isDragging.value = false
+  dragOffsetY.value = 0
+  dragState.startY = 0
+}
+
+function onTouchStart(event: TouchEvent) {
+  if (isDesktop.value || event.touches.length !== 1 || isInteractiveTarget(event.target)) {
+    return
+  }
+
+  if ((scroller.value?.scrollTop ?? 0) > 0) {
+    return
+  }
+
+  isDragging.value = true
+  dragState.startY = event.touches[0]?.clientY ?? 0
+}
+
+function onTouchMove(event: TouchEvent) {
+  if (!isDragging.value || event.touches.length !== 1) {
+    return
+  }
+
+  const distance = (event.touches[0]?.clientY ?? 0) - dragState.startY
+  dragOffsetY.value = Math.max(0, distance)
+
+  if (dragOffsetY.value > 0 && event.cancelable) {
+    event.preventDefault()
+  }
+}
+
+function onTouchEnd() {
+  if (!isDragging.value) {
+    return
+  }
+
+  if (dragOffsetY.value >= dragCloseThreshold) {
+    close()
+    return
+  }
+
+  resetDrag()
 }
 
 function pickWeightedAd(ads: Ad[]) {
@@ -117,52 +207,101 @@ onUnmounted(() => {
   <div
     :aria-label="sessionInfo?.title"
     aria-modal="true"
-    class="bg-black/50 inset-0 fixed z-modal"
+    class="bg-black/50 flex items-end inset-0 justify-center fixed z-modal sm:items-center"
     role="dialog"
     @click.self="close"
   >
-    <div class="bg-white flex flex-row-reverse h-full w-full right-0 top-0 fixed sm:w-auto">
-      <NuxtLink
-        v-if="randomAd && isDesktop"
-        class="shrink-0 h-full aspect-[1/4]"
-        target="_blank"
-        :to="randomAd.link"
-      >
-        <!-- AD -->
-        <NuxtImg
-          :alt="randomAd.id"
-          class="h-full w-full object-contain"
-          :src="randomAd.imageVertical"
-        />
-      </NuxtLink>
+    <div
+      class="rounded-lg bg-white flex flex-col h-80vh max-w-5xl w-full transition-transform duration-200 ease-out overflow-hidden sm:h-70vh sm:w-80vw"
+      :style="sheetStyle"
+      @touchcancel="resetDrag"
+      @touchend="onTouchEnd"
+      @touchmove="onTouchMove"
+      @touchstart="onTouchStart"
+    >
+      <div
+        class="h-2"
+        :style="{ backgroundColor: sessionTrackColor }"
+      />
 
-      <div class="p-3 h-full w-full overflow-y-auto sm:w-120">
-        <div class="flex top-0 justify-end sticky z-content">
-          <button
-            aria-label="close"
-            class="text-gray-500 rounded-full flex h-8 w-8 transition-colors items-center justify-center hover:bg-gray-100"
-            type="button"
-            @click="close"
-          >
-            <Icon
-              class="h-4 w-4"
-              name="tabler:x"
-            />
-          </button>
+      <div class="flex flex-1 min-h-0">
+        <NuxtLink
+          v-if="randomAd && isDesktop"
+          class="shrink-0 h-full aspect-[1/4]"
+          target="_blank"
+          :to="randomAd.link"
+        >
+          <!-- AD -->
+          <NuxtImg
+            :alt="randomAd.id"
+            class="h-full w-full object-contain"
+            :src="randomAd.imageVertical"
+          />
+        </NuxtLink>
+
+        <div
+          ref="scroller"
+          class="h-full w-full overflow-y-auto"
+        >
+          <div class="py-2 flex justify-center sm:hidden">
+            <div class="rounded-full bg-gray-300 h-1 w-10" />
+          </div>
+
+          <div class="mr-4 flex gap-2 h-0 top-5 justify-end relative z-content overflow-visible sm:mr-6">
+            <button
+              :aria-label="isFavorite(sessionId) ? t('removeFavorite') : t('addFavorite')"
+              class="text-sm font-500 px-3 border-2 rounded flex gap-1 h-8 cursor-pointer transition-colors items-center"
+              :class="isFavorite(sessionId) ? 'bg-favorite border-favorite text-white' : 'bg-gray-100 border-gray-300 hover:bg-gray-200'"
+              @click="toggleFavorite(sessionId)"
+            >
+              <Icon
+                class="h-4 w-4"
+                :class="isFavorite(sessionId) ? 'text-white' : 'text-gray-500'"
+                :name="isFavorite(sessionId) ? 'tabler:star-filled' : 'tabler:star'"
+              />
+              <span class="hidden sm:inline">{{ isFavorite(sessionId) ? t('saved') : t('save') }}</span>
+            </button>
+            <button
+              aria-label="close"
+              class="text-gray-500 rounded flex h-8 w-8 cursor-pointer transition-colors items-center justify-center hover:bg-gray-100"
+              type="button"
+              @click="close"
+            >
+              <Icon
+                class="h-5 w-5"
+                name="tabler:x"
+              />
+            </button>
+          </div>
+
+          <CpSessionInfoCard
+            v-if="sessionInfo"
+            :ad="randomAd"
+            :co-write="sessionInfo.coWrite"
+            :description="sessionInfo.description"
+            has-title-margin-right
+            :room="sessionInfo.room"
+            :speakers="sessionInfo.speakers"
+            :tags="sessionInfo.tags"
+            :time="sessionInfo.time"
+            :title="sessionInfo.title"
+            :track="sessionInfo.track"
+          />
         </div>
-
-        <CpSessionInfoCard
-          v-if="sessionInfo"
-          :ad="randomAd"
-          :co-write="sessionInfo.coWrite"
-          :description="sessionInfo.description"
-          :room="sessionInfo.room"
-          :speakers="sessionInfo.speakers"
-          :tags="sessionInfo.tags"
-          :time="sessionInfo.time"
-          :title="sessionInfo.title"
-        />
       </div>
     </div>
   </div>
 </template>
+
+<i18n lang="yaml">
+  en:
+    addFavorite: 'Save session'
+    removeFavorite: 'Remove from favorites'
+    save: 'Save'
+    saved: 'Saved'
+  zh:
+    addFavorite: '收藏議程'
+    removeFavorite: '取消收藏議程'
+    save: '收藏'
+    saved: '已收藏'
+</i18n>

--- a/app/pages/session/[id].vue
+++ b/app/pages/session/[id].vue
@@ -1,11 +1,10 @@
 <script setup lang="ts">
 import type { Ad } from '#shared/types/ad'
-import type { SessionDetail, SessionSummary } from '#shared/types/session'
+import type { SessionDetail } from '#shared/types/session'
 import { useMediaQuery } from '@vueuse/core'
 import { useI18n } from 'vue-i18n'
 import CpSessionInfoCard from '~/components/feature/CpSessionInfoCard.vue'
 import { useFavorites } from '~/composables/useFavorites'
-import { buildTrackColorMap, trackKey } from '~/utils/tracks'
 
 const { t, locale } = useI18n()
 const route = useRoute()
@@ -28,24 +27,10 @@ if (error.value) {
     ? createError({ status: 404, statusText: 'Page Not Found' })
     : error.value
 }
-const { data: sessionsByDay } = await useFetch<Record<string, SessionSummary[]>>('/api/session')
 const { data: ad } = await useFetch<Ad[]>('/api/ad')
 const randomAd = ref<Ad | null>(null)
 
 const localeKey = computed(() => locale.value === 'zh' ? 'zh' : 'en')
-
-const sessionTrackColor = computed(() => {
-  const session = sessionDetail.value
-  if (!session?.start) {
-    return '#e76f51'
-  }
-
-  const day = session.start.slice(0, 10)
-  const daySessions = sessionsByDay.value?.[day] ?? []
-  const trackColors = buildTrackColorMap(daySessions)
-
-  return trackColors.get(trackKey(session)) ?? '#e76f51'
-})
 
 const sessionInfo = computed(() => {
   if (!sessionDetail.value) {
@@ -62,7 +47,7 @@ const sessionInfo = computed(() => {
         name: locale.value === 'zh'
           ? (sessionDetail.value.track?.name?.['zh-hant'] || sessionDetail.value.track?.name?.en || '')
           : (sessionDetail.value.track?.name?.en || sessionDetail.value.track?.name?.['zh-hant'] || ''),
-        color: sessionTrackColor.value,
+        color: sessionDetail.value.trackColor,
       }
     : undefined
 
@@ -221,7 +206,7 @@ onUnmounted(() => {
     >
       <div
         class="h-2"
-        :style="{ backgroundColor: sessionTrackColor }"
+        :style="{ backgroundColor: sessionDetail?.trackColor ?? '#e76f51' }"
       />
 
       <div class="flex flex-1 min-h-0">

--- a/app/pages/session/[id].vue
+++ b/app/pages/session/[id].vue
@@ -5,6 +5,7 @@ import { useMediaQuery } from '@vueuse/core'
 import { useI18n } from 'vue-i18n'
 import CpSessionInfoCard from '~/components/feature/CpSessionInfoCard.vue'
 import { useFavorites } from '~/composables/useFavorites'
+import { DEFAULT_TRACK_COLOR } from '~/utils/tracks'
 
 const { t, locale } = useI18n()
 const route = useRoute()
@@ -206,7 +207,7 @@ onUnmounted(() => {
     >
       <div
         class="h-2"
-        :style="{ backgroundColor: sessionDetail?.trackColor ?? '#e76f51' }"
+        :style="{ backgroundColor: sessionDetail?.trackColor ?? DEFAULT_TRACK_COLOR }"
       />
 
       <div class="flex flex-1 min-h-0">

--- a/app/utils/tracks.ts
+++ b/app/utils/tracks.ts
@@ -1,5 +1,6 @@
 export {
   buildTrackColorMap,
+  DEFAULT_TRACK_COLOR,
   isMainTrack,
   NO_TRACK,
   TRACK_COLORS,

--- a/app/utils/tracks.ts
+++ b/app/utils/tracks.ts
@@ -1,59 +1,7 @@
-import type { SessionSummary, SessionTrack } from '#shared/types/session'
-
-// Per-track solid card background, ordered by sorted track index (from the Figma spec §5).
-// Shared by both the room table (CpSessionTable) and the track table (CpSessionTrackTable)
-// so a given track keeps the same colour in either view. Keep the two in sync.
-export const TRACK_COLORS = [
-  '#e76f51',
-  '#ff6b6b',
-  '#4ecdc4',
-  '#45b7d1',
-  '#ffa07a',
-  '#98d8c8',
-  '#f7dc6f',
-  '#bb8fce',
-  '#85c1e2',
-  '#f8b195',
-  '#f67280',
-  '#c06c84',
-  '#6c5b7b',
-  '#355c7d',
-  '#2a9d8f',
-  '#264653',
-  '#e9c46a',
-  '#f4a261',
-  '#e63946',
-  '#457b9d',
-  '#1d3557',
-  '#a8dadc',
-]
-
-// Track-less sessions collapse into one fallback bucket so nothing disappears.
-export const NO_TRACK = '__none__'
-
-export function trackKey(session: SessionSummary): string {
-  return session.track?.id != null ? String(session.track.id) : NO_TRACK
-}
-
-// Match by name (either locale) since Pretalx track ids aren't stable across events.
-const MAIN_TRACK_NAMES = ['主議程', 'Main Session Track']
-export function isMainTrack(name?: SessionTrack['name']): boolean {
-  return MAIN_TRACK_NAMES.includes(name?.['zh-hant'] ?? '') || MAIN_TRACK_NAMES.includes(name?.en ?? '')
-}
-
-/**
- * Assign a stable colour per track: distinct tracks sorted by id (track-less last),
- * indexed into the palette. Both table views build this from the same day's sessions,
- * so a track resolves to the same colour in either layout.
- */
-export function buildTrackColorMap(sessions: SessionSummary[]): Map<string, string> {
-  const order = new Map<string, number>()
-  for (const session of sessions) {
-    const key = trackKey(session)
-    if (!order.has(key)) {
-      order.set(key, session.track?.id ?? Number.POSITIVE_INFINITY)
-    }
-  }
-  const sorted = [...order.entries()].sort((a, b) => a[1] - b[1])
-  return new Map(sorted.map(([key], index) => [key, TRACK_COLORS[index % TRACK_COLORS.length]!]))
-}
+export {
+  buildTrackColorMap,
+  isMainTrack,
+  NO_TRACK,
+  TRACK_COLORS,
+  trackKey,
+} from '#shared/utils/tracks'

--- a/server/api/session/[id]/index.get.ts
+++ b/server/api/session/[id]/index.get.ts
@@ -31,14 +31,14 @@ export default defineEventHandler(async (event) => {
   }
 
   const session = buildSessionSummary(submission, data)
-  if (!session) {
+  if (!session?.start) {
     throw createError({
       statusCode: 404,
       statusMessage: 'Not Found',
     })
   }
 
-  const day = session.start!.slice(0, 10)
+  const day = session.start.slice(0, 10)
   const daySessions = data.submissions.arr
     .filter((item) => item.state === 'confirmed')
     .map((item) => buildSessionSummary(item, data))

--- a/server/api/session/[id]/index.get.ts
+++ b/server/api/session/[id]/index.get.ts
@@ -1,7 +1,7 @@
 import type { SessionSummary } from '#shared/types/session'
 import pretalxData from '#server/utils/pretalx'
 import { buildSessionSummary } from '#server/utils/pretalx/sessions'
-import { buildTrackColorMap, trackKey } from '#shared/utils/tracks'
+import { buildTrackColorMap, DEFAULT_TRACK_COLOR, trackKey } from '#shared/utils/tracks'
 
 export default defineEventHandler(async (event) => {
   const id = getRouterParam(event, 'id')!
@@ -48,7 +48,7 @@ export default defineEventHandler(async (event) => {
 
   return {
     ...session,
-    trackColor: trackColors.get(trackKey(session)) ?? '#e76f51',
+    trackColor: trackColors.get(trackKey(session)) ?? DEFAULT_TRACK_COLOR,
     co_write: null,
     qa: null,
     slide: null,

--- a/server/api/session/[id]/index.get.ts
+++ b/server/api/session/[id]/index.get.ts
@@ -1,5 +1,7 @@
+import type { SessionSummary } from '#shared/types/session'
 import pretalxData from '#server/utils/pretalx'
-import { parseAnswer, parseDifficulty, parseSlot, parseSpeaker, parseTags, parseTrack, parseType } from '#server/utils/pretalx/parser'
+import { buildSessionSummary } from '#server/utils/pretalx/sessions'
+import { buildTrackColorMap, trackKey } from '#shared/utils/tracks'
 
 export default defineEventHandler(async (event) => {
   const id = getRouterParam(event, 'id')!
@@ -28,31 +30,25 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const answers = parseAnswer(submission.answers, data)
-  const slot = parseSlot(submission.slots[0], data)
-  const speakers = parseSpeaker(submission.speakers, data)
-  const type = parseType(submission.submission_type, data)
+  const session = buildSessionSummary(submission, data)
+  if (!session) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: 'Not Found',
+    })
+  }
+
+  const day = session.start!.slice(0, 10)
+  const daySessions = data.submissions.arr
+    .filter((item) => item.state === 'confirmed')
+    .map((item) => buildSessionSummary(item, data))
+    .filter((item): item is SessionSummary => item !== null && item.start?.startsWith(day) === true)
+
+  const trackColors = buildTrackColorMap(daySessions)
 
   return {
-    id: submission.code,
-    room: slot?.room?.name,
-    start: slot?.start,
-    end: slot?.end,
-    language: answers.language,
-    track: parseTrack(submission.track, data),
-    speakers,
-    zh: {
-      title: submission.title,
-      describe: submission.abstract,
-      type: type.name['zh-hant'] || type.name.en,
-    },
-    en: {
-      title: answers.enTitle || submission.title,
-      describe: answers.enDesc || submission.abstract,
-      type: type.name.en || type.name['zh-hant'],
-    },
-    tags: parseTags(submission.tags, data, parseDifficulty(answers.difficulty)),
-    uri: `https://coscup.org/2026/session/${submission.code}`,
+    ...session,
+    trackColor: trackColors.get(trackKey(session)) ?? '#e76f51',
     co_write: null,
     qa: null,
     slide: null,

--- a/shared/types/session.ts
+++ b/shared/types/session.ts
@@ -46,6 +46,7 @@ export const SessionSummarySchema = z.object({
 })
 
 export const SessionDetailSchema = SessionSummarySchema.extend({
+  trackColor: z.string(),
   co_write: z.null(),
   qa: z.null(),
   slide: z.null(),

--- a/shared/utils/tracks.ts
+++ b/shared/utils/tracks.ts
@@ -27,6 +27,7 @@ export const TRACK_COLORS = [
   '#1d3557',
   '#a8dadc',
 ]
+export const DEFAULT_TRACK_COLOR = TRACK_COLORS[0]!
 
 // Track-less sessions collapse into one fallback bucket so nothing disappears.
 export const NO_TRACK = '__none__'

--- a/shared/utils/tracks.ts
+++ b/shared/utils/tracks.ts
@@ -1,0 +1,59 @@
+import type { SessionSummary, SessionTrack } from '#shared/types/session'
+
+// Per-track solid card background, ordered by sorted track index (from the Figma spec §5).
+// Shared by both the room table (CpSessionTable) and server-rendered session detail pages
+// so a given track keeps the same colour in either view.
+export const TRACK_COLORS = [
+  '#e76f51',
+  '#ff6b6b',
+  '#4ecdc4',
+  '#45b7d1',
+  '#ffa07a',
+  '#98d8c8',
+  '#f7dc6f',
+  '#bb8fce',
+  '#85c1e2',
+  '#f8b195',
+  '#f67280',
+  '#c06c84',
+  '#6c5b7b',
+  '#355c7d',
+  '#2a9d8f',
+  '#264653',
+  '#e9c46a',
+  '#f4a261',
+  '#e63946',
+  '#457b9d',
+  '#1d3557',
+  '#a8dadc',
+]
+
+// Track-less sessions collapse into one fallback bucket so nothing disappears.
+export const NO_TRACK = '__none__'
+
+export function trackKey(session: SessionSummary): string {
+  return session.track?.id != null ? String(session.track.id) : NO_TRACK
+}
+
+// Match by name (either locale) since Pretalx track ids aren't stable across events.
+const MAIN_TRACK_NAMES = ['主議程', 'Main Session Track']
+export function isMainTrack(name?: SessionTrack['name']): boolean {
+  return MAIN_TRACK_NAMES.includes(name?.['zh-hant'] ?? '') || MAIN_TRACK_NAMES.includes(name?.en ?? '')
+}
+
+/**
+ * Assign a stable colour per track: distinct tracks sorted by id (track-less last),
+ * indexed into the palette. Both table views build this from the same day's sessions,
+ * so a track resolves to the same colour in either layout.
+ */
+export function buildTrackColorMap(sessions: SessionSummary[]): Map<string, string> {
+  const order = new Map<string, number>()
+  for (const session of sessions) {
+    const key = trackKey(session)
+    if (!order.has(key)) {
+      order.set(key, session.track?.id ?? Number.POSITIVE_INFINITY)
+    }
+  }
+  const sorted = [...order.entries()].sort((a, b) => a[1] - b[1])
+  return new Map(sorted.map(([key], index) => [key, TRACK_COLORS[index % TRACK_COLORS.length]!]))
+}

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -49,6 +49,7 @@ export default defineConfig({
             'cp-orange-500': '#F97316',
             'cp-orange-600': '#EA580C',
             'cp-orange-700': '#C2410C',
+            'favorite': '#f0b100',
           },
         },
       },


### PR DESCRIPTION
close #211

## Summary

更新議程詳情彈窗的版面，讓使用者在查看單一議程時能直接收藏、辨識議程軌，並在手機上以更接近 bottom sheet 的方式操作。

## Changes

- 調整議程詳情 modal 為置中的固定尺寸彈窗，手機版改為 bottom sheet 形式。
- 新增手機版向下拖曳關閉互動，並保留點擊遮罩與 Escape 關閉。
- 在詳情彈窗加入收藏按鈕，支援已收藏 / 未收藏狀態與 i18n 文案。
- 顯示議程軌標籤，並連結到對應的 track 頁面。
- 將 track 顏色計算邏輯抽到 shared util，讓前端議程表與 server API 共用同一套規則。
- 讓單一議程 API 回傳 trackColor，議程詳情頁不須額外抓完整 /api/session。
- 重新整理議程資訊卡版面、間距、講者介紹區塊與手機版廣告位置。
- 新增 `favorite` UnoCSS theme color 供收藏狀態使用。

## Impact

 - 影響議程詳情頁 app/pages/session/[id].vue 的 UI、互動行為與資料取得方式。
 - 影響 CpSessionInfoCard 的 props 與顯示內容。
 - 影響單一議程 API 回傳資料，新增 trackColor 欄位。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Session pages now display track info with localized links and consistent track color accents across tables and the session header/details.
  * Mobile session dialog has been redesigned into a draggable bottom sheet with improved touch behavior, and favorite/close controls moved into the scrollable area.
* **Bug Fixes**
  * Updated the Chinese session abstract text to the corrected wording.
* **UI Improvements**
  * Improved responsive rendering for speakers, abstracts, and tag styling, including language-aware spacing and layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->