### PR TITLE
fix(opass): stringify type and room ids

### DIFF
--- a/server/utils/opass/pretalxToOpass.ts
+++ b/server/utils/opass/pretalxToOpass.ts
@@ -28,8 +28,8 @@ export function pretalxToOpass(pretalxData: PretalxResult) {
 
       return {
         id: submission.code,
-        type: submission.submission_type,
-        room: slot?.room?.id,
+        type: String(submission.submission_type),
+        room: slot?.room?.id != null ? String(slot.room.id) : undefined,
         start: slot?.start,
         end: slot?.end,
         language: answer.language,
@@ -85,7 +85,7 @@ export function pretalxToOpass(pretalxData: PretalxResult) {
     }
 
     return {
-      id: type.id,
+      id: String(type.id),
       zh: {
         name: type.name['zh-hant'] || type.name.en,
       },
@@ -107,7 +107,7 @@ export function pretalxToOpass(pretalxData: PretalxResult) {
       }
 
       return {
-        id: room.id,
+        id: String(room.id),
         zh: {
           name: room.name['zh-hant'] || room.name.en,
         },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility and consistency by ensuring session types, rooms, and related identifiers are represented as text.
  * Prevented invalid room values from appearing when a session has no assigned room.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->