### PR TITLE
fix(opass): correct property name from 'describe' to 'description' in session data

### DIFF
--- a/server/utils/opass/pretalxToOpass.ts
+++ b/server/utils/opass/pretalxToOpass.ts
@@ -36,11 +36,11 @@ export function pretalxToOpass(pretalxData: PretalxResult) {
         speakers: submission.speakers,
         zh: {
           title: submission.title,
-          describe: submission.abstract,
+          description: submission.abstract,
         },
         en: {
           title: answer.enTitle || submission.title,
-          describe: answer.enDesc || submission.abstract,
+          description: answer.enDesc || submission.abstract,
         },
         tags: tags.map((tag) => tag.id),
         uri: `https://coscup.org/2026/session/${submission.code}`,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected localized session descriptions so they are displayed consistently in the expected description field for Chinese and English content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->