### PR TITLE
fix: prevent session table info overflow on mobile

### DIFF
--- a/app/layouts/session-table.vue
+++ b/app/layouts/session-table.vue
@@ -19,7 +19,7 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div class="w-max">
+  <div class="sm:w-max">
     <CpNavbar class="w-[var(--viewport-width,100vw)] left-0 sticky z-dropdown" />
     <main class="sm:w-max">
       <slot />


### PR DESCRIPTION
接續 #252 的修正

原本的 c212d8e 改了兩處斷點，而合併的 commit [6459076](https://github.com/COSCUP/2026/pull/252/changes/64590764d115f0200707c4d451ce8429caabe4e1) 改掉其中一個斷點，導致 issue #247 依舊存在

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the session table layout on small screens by enabling responsive width behavior.
  * Preserved existing sizing for the navigation, main content, and footer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->