### PR TITLE
fix: keep session day selected when opening details

### DIFF
--- a/app/components/feature/CpSessionList.vue
+++ b/app/components/feature/CpSessionList.vue
@@ -11,14 +11,9 @@ const { sessions: _sessions, preview = false } = defineProps<{
 }>()
 
 const { locale, t } = useI18n()
-const route = useRoute()
 const localePath = useLocalePath()
 const { isFavorite, toggleFavorite } = useFavorites()
 const favoriteLabel = useFavoriteLabel(t)
-
-function sessionPath(id: string) {
-  return localePath({ path: `/session/${id}`, query: route.query })
-}
 
 const sessions = computed(() => {
   if (!_sessions) {
@@ -67,7 +62,7 @@ const times = computed(() => Object.keys(sessions.value).sort())
           :start="session.start"
           :tags="session.tags"
           :title="session.title"
-          :to="sessionPath(session.id)"
+          :to="localePath(`/session/${session.id}`)"
           @toggle-favorite="toggleFavorite(session.id)"
         />
       </div>

--- a/app/components/feature/CpSessionTable.vue
+++ b/app/components/feature/CpSessionTable.vue
@@ -21,7 +21,6 @@ const { sessions: _sessions, trackColors, day, timeRange, interval, rowHeight, c
 
 const { t, locale } = useI18n()
 const { time } = useRealtime()
-const route = useRoute()
 const localePath = useLocalePath()
 const { isFavorite, toggleFavorite } = useFavorites()
 const favoriteLabel = useFavoriteLabel(t)
@@ -33,10 +32,6 @@ const TIME_COL_WIDTH = 64
 const HEADER_HEIGHT = 58
 
 const isZh = computed(() => locale.value !== 'en')
-
-function sessionPath(id: string) {
-  return localePath({ path: `/session/${id}`, query: route.query })
-}
 
 function parseMinutes(isoStr: string) {
   const match = isoStr.match(/T(\d{2}):(\d{2})/)
@@ -401,7 +396,7 @@ const sessions = computed(() =>
         :aria-label="session.title"
         class="inset-0 absolute"
         :draggable="false"
-        :to="sessionPath(session.id)"
+        :to="localePath(`/session/${session.id}`)"
         @dragstart.prevent
       />
 

--- a/app/pages/session.vue
+++ b/app/pages/session.vue
@@ -29,6 +29,17 @@ const queryDay = computed(() => {
   const day = route.query.day
   return typeof day === 'string' && days.value.includes(day) ? day : null
 })
+const routeSessionDay = computed(() => {
+  const id = route.params.id
+  const sessionId = typeof id === 'string' ? id : null
+  if (!sessionId) {
+    return null
+  }
+
+  return Object.entries(data.value ?? {})
+    .find(([, sessions]) => sessions.some((session) => session.id === sessionId))
+    ?.[0] ?? null
+})
 
 // A `?filter=` link carries someone else's favorites, to preview and import.
 const hasShareLink = computed(() => String(route.query.filter ?? '').length > 0)
@@ -53,7 +64,7 @@ const firstSharedDay = computed(() => {
 })
 
 const selectedDay = computed({
-  get: () => queryDay.value ?? firstSharedDay.value ?? days.value[0] ?? null,
+  get: () => queryDay.value ?? routeSessionDay.value ?? firstSharedDay.value ?? days.value[0] ?? null,
   set: (value) => {
     const nextQuery = { ...route.query }
 

--- a/app/pages/session/[id].vue
+++ b/app/pages/session/[id].vue
@@ -32,6 +32,7 @@ const { data: ad } = await useFetch<Ad[]>('/api/ad')
 const randomAd = ref<Ad | null>(null)
 
 const localeKey = computed(() => locale.value === 'zh' ? 'zh' : 'en')
+const sessionDay = computed(() => sessionDetail.value?.start?.slice(0, 10) ?? null)
 
 const sessionInfo = computed(() => {
   if (!sessionDetail.value) {
@@ -79,7 +80,8 @@ useSeoMeta({
 })
 
 function close() {
-  router.push(localePath({ path: '/session', query: route.query }))
+  const day = sessionDay.value
+  router.push(localePath(day ? { path: '/session', query: { day } } : { path: '/session' }))
 }
 
 const sheetStyle = computed(() => ({

--- a/app/pages/session/[id].vue
+++ b/app/pages/session/[id].vue
@@ -32,6 +32,7 @@ const { data: ad } = await useFetch<Ad[]>('/api/ad')
 const randomAd = ref<Ad | null>(null)
 
 const localeKey = computed(() => locale.value === 'zh' ? 'zh' : 'en')
+// Extract the yyyy-MM-dd part from the session start date.
 const sessionDay = computed(() => sessionDetail.value?.start?.slice(0, 10) ?? null)
 
 const sessionInfo = computed(() => {


### PR DESCRIPTION
## Summary

修改議程列表進入詳情頁時的日期狀態處理，由 session id 對應議程資料推得日期。

## Changes

- 議程卡片連到詳情頁時不再帶入日期 query，改為純 `/session/{id}`。
- `session.vue` 在子路由為 session detail 時，會用 `route.params.id` 從已載入的 session data 找出對應日期。
- `selectedDay` 的 fallback 順序加入 session id 對應日期，避免沒有 `day` query 時跳回第一天。
- 關閉詳情頁時仍依 `sessionDetail.start` 回到 `/session?day=YYYY-MM-DD`。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation to session details by using clean, consistent session links.
  * Selecting or opening a session now correctly identifies and displays its associated day.
  * Returning from a session detail view preserves the relevant day when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->