### PR TITLE
fix: generate valid OPass JSON according to official schema

### DIFF
--- a/server/utils/opass/pretalxToOpass.ts
+++ b/server/utils/opass/pretalxToOpass.ts
@@ -1,13 +1,13 @@
-import type { OpassTag } from '#server/utils/opass/tags'
+import type { OpassNamedEntity, OpassSchedule, OpassSession, OpassSpeaker } from '#server/utils/opass/types'
 import type { PretalxResult, Room, Speaker, Submission, SubmissionType } from '#shared/types/pretalx'
 import { sessionTags } from '#server/utils/opass/tags'
 import { parseAnswer, parseSlot } from '#server/utils/pretalx/parser'
 
-export function pretalxToOpass(pretalxData: PretalxResult) {
+export function pretalxToOpass(pretalxData: PretalxResult): OpassSchedule {
   const speakerIds: Set<Speaker['code']> = new Set()
   const roomIds: Set<Room['id']> = new Set()
   const typeIds: Set<SubmissionType['id']> = new Set()
-  const tagMap = new Map<string, OpassTag>()
+  const tagMap = new Map<string, OpassNamedEntity>()
 
   const sessions = pretalxData.submissions.arr
     .filter((submission: Submission) => submission.state === 'confirmed')
@@ -29,9 +29,9 @@ export function pretalxToOpass(pretalxData: PretalxResult) {
       return {
         id: submission.code,
         type: String(submission.submission_type),
-        room: slot?.room?.id != null ? String(slot.room.id) : undefined,
-        start: slot?.start,
-        end: slot?.end,
+        room: slot?.room?.id?.toString() ?? '',
+        start: slot?.start ?? '2026-08-08T08:00:00Z',
+        end: slot?.end ?? '2026-08-08T08:00:00Z',
         language: answer.language,
         speakers: submission.speakers,
         zh: {
@@ -44,11 +44,7 @@ export function pretalxToOpass(pretalxData: PretalxResult) {
         },
         tags: tags.map((tag) => tag.id),
         uri: `https://coscup.org/2026/session/${submission.code}`,
-        co_write: '',
-        qa: '',
-        slide: '',
-        record: '',
-      }
+      } satisfies OpassSession
     })
 
   const speakers = Array.from(speakerIds, (id: Speaker['code']) => {
@@ -63,7 +59,7 @@ export function pretalxToOpass(pretalxData: PretalxResult) {
 
     return {
       id: speaker.code,
-      avatar: speaker.avatar_url ?? '',
+      avatar: speaker.avatar_url ?? 'https://placehold.co/300x300.png',
       zh: {
         name: answer.zhName || speaker.name,
         bio: answer.zhBio || speaker.biography,
@@ -72,7 +68,7 @@ export function pretalxToOpass(pretalxData: PretalxResult) {
         name: answer.enName || speaker.name,
         bio: answer.enBio || speaker.biography,
       },
-    }
+    } satisfies OpassSpeaker
   })
     .filter((x): x is NonNullable<typeof x> => x !== null)
 
@@ -92,7 +88,7 @@ export function pretalxToOpass(pretalxData: PretalxResult) {
       en: {
         name: type.name.en || type.name['zh-hant'],
       },
-    }
+    } satisfies OpassNamedEntity
   })
     .filter((x): x is NonNullable<typeof x> => x !== null)
 
@@ -114,9 +110,16 @@ export function pretalxToOpass(pretalxData: PretalxResult) {
         en: {
           name: room.name.en || room.name['zh-hant'],
         },
-      }
+      } satisfies OpassNamedEntity
     })
     .filter((x): x is NonNullable<typeof x> => x !== null)
 
-  return { sessions, speakers, session_types: types, rooms, tags: [...tagMap.values()] }
+  // run schema check to ensure the structure is valid
+  return opassScheduleSchema.parse({
+    sessions,
+    speakers,
+    session_types: types,
+    rooms,
+    tags: [...tagMap.values()],
+  } satisfies OpassSchedule)
 }

--- a/server/utils/opass/pretalxToOpass.ts
+++ b/server/utils/opass/pretalxToOpass.ts
@@ -1,6 +1,7 @@
 import type { OpassNamedEntity, OpassSchedule, OpassSession, OpassSpeaker } from '#server/utils/opass/types'
 import type { PretalxResult, Room, Speaker, Submission, SubmissionType } from '#shared/types/pretalx'
 import { sessionTags } from '#server/utils/opass/tags'
+import { opassScheduleSchema } from '#server/utils/opass/types'
 import { parseAnswer, parseSlot } from '#server/utils/pretalx/parser'
 
 export function pretalxToOpass(pretalxData: PretalxResult): OpassSchedule {

--- a/server/utils/opass/tags.ts
+++ b/server/utils/opass/tags.ts
@@ -1,14 +1,5 @@
+import type { OpassNamedEntity } from './types'
 import { parseDifficulty } from '#server/utils/pretalx/parser'
-
-// OPass app 的 tag 分類沿用 2025：議程以 slug id 參照 tag，
-// 而頂層 `tags` 字典提供每個 slug 的多語名稱。分類僅含語言與難度，
-// 不含 pretalx 自訂標籤。
-
-export interface OpassTag {
-  id: string
-  zh: { name: string }
-  en: { name: string }
-}
 
 // 投稿語言原始字串 → 通用語言鍵（沿用 2025）。
 const LANGUAGE_GENERALIZE_MAP: Record<string, string> = {
@@ -42,14 +33,14 @@ const TAG_NAMES: Record<string, { zh: string, en: string }> = {
   'Professional': { zh: '專業', en: 'Professional' },
 }
 
-function buildTag(id: string, key: string): OpassTag {
+function buildTag(id: string, key: string): OpassNamedEntity {
   const name = TAG_NAMES[key]!
   return { id, zh: { name: name.zh }, en: { name: name.en } }
 }
 
 // 由語言與難度算出議程的 tag 字典項目（含 slug id 與多語名稱）。
-export function sessionTags(language: string | undefined, difficultyRaw: string | undefined): OpassTag[] {
-  const tags: OpassTag[] = []
+export function sessionTags(language: string | undefined, difficultyRaw: string | undefined): OpassNamedEntity[] {
+  const tags: OpassNamedEntity[] = []
 
   const lang = language ? LANGUAGE_GENERALIZE_MAP[language] : undefined
   if (lang) {

--- a/server/utils/opass/types.ts
+++ b/server/utils/opass/types.ts
@@ -1,0 +1,70 @@
+/**
+ * Generated from https://github.com/CCIP-App/schedule-json-validator/blob/38cff3eabbde4cb6d84e3a19accf7e620a29eab7/schemas/opass-schedule.v1.schema.json
+ */
+
+import { z } from 'zod'
+
+const idSchema = z.string().min(1)
+
+const stringListSchema = z.array(z.string())
+
+const localizedSessionSchema = z.looseObject({
+  title: z.string(),
+  description: z.string(),
+})
+
+const localizedSpeakerSchema = z.looseObject({
+  name: z.string(),
+  bio: z.string(),
+})
+
+const localizedNameSchema = z.looseObject({
+  name: z.string(),
+  description: z.string().optional(),
+})
+
+export const opassSessionSchema = z.looseObject({
+  id: idSchema,
+  room: idSchema,
+  type: idSchema.optional(),
+  start: z.iso.datetime({ offset: true }),
+  end: z.iso.datetime({ offset: true }),
+  zh: localizedSessionSchema,
+  en: localizedSessionSchema,
+  speakers: stringListSchema,
+  tags: stringListSchema,
+  broadcast: stringListSchema.optional(),
+  uri: z.string().optional(),
+  qa: z.string().optional(),
+  slide: z.string().optional(),
+  live: z.string().optional(),
+  record: z.string().optional(),
+  language: z.string().optional(),
+  co_write: z.string().optional(),
+})
+
+export const opassSpeakerSchema = z.looseObject({
+  id: idSchema,
+  avatar: z.string(),
+  zh: localizedSpeakerSchema,
+  en: localizedSpeakerSchema,
+})
+
+export const opassNamedEntitySchema = z.looseObject({
+  id: idSchema,
+  zh: localizedNameSchema,
+  en: localizedNameSchema,
+})
+
+export const opassScheduleSchema = z.looseObject({
+  sessions: z.array(opassSessionSchema),
+  speakers: z.array(opassSpeakerSchema),
+  session_types: z.array(opassNamedEntitySchema),
+  rooms: z.array(opassNamedEntitySchema),
+  tags: z.array(opassNamedEntitySchema),
+})
+
+export type OpassSession = z.infer<typeof opassSessionSchema>
+export type OpassSpeaker = z.infer<typeof opassSpeakerSchema>
+export type OpassNamedEntity = z.infer<typeof opassNamedEntitySchema>
+export type OpassSchedule = z.infer<typeof opassScheduleSchema>


### PR DESCRIPTION
一週前 OPass 推出了官方的 schema，可以用這個來撰寫 TypeScript 的 Zod
Schema，然後驗證：https://github.com/CCIP-App/schedule-json-validator/blob/38cff3eabbde4cb6d84e3a19accf7e620a29eab7/schemas/opass-schedule.v1.schema.json
