### PR TITLE
fix: place title and button on separate rows in session modal

### DIFF
--- a/app/components/feature/CpSessionDetailModal.vue
+++ b/app/components/feature/CpSessionDetailModal.vue
@@ -196,7 +196,7 @@ onUnmounted(() => {
             <div class="rounded-full bg-gray-300 h-1 w-10" />
           </div>
 
-          <div class="mr-4 flex gap-2 h-0 top-5 justify-end relative z-content overflow-visible sm:mr-6">
+          <div class="mr-4 mt-2 flex gap-2 justify-end sm:mr-6 sm:mt-4">
             <CpSessionDetailShareButton :title="title" />
             <button
               :aria-label="isFavorite(sessionId) ? t('removeFavorite') : t('addFavorite')"
@@ -228,7 +228,6 @@ onUnmounted(() => {
             :ad="randomAd"
             :co-write="coWrite"
             :description="description"
-            has-title-margin-right
             :room="room"
             :speakers="speakers"
             :tags="tags"

--- a/app/components/feature/CpSessionInfoCard.vue
+++ b/app/components/feature/CpSessionInfoCard.vue
@@ -23,7 +23,6 @@ const props = defineProps<{
   }
   description: string
   ad: Ad | null
-  hasTitleMarginRight?: boolean
 }>()
 
 const { t, locale } = useI18n()
@@ -37,12 +36,9 @@ const speakerNames = computed(() =>
 </script>
 
 <template>
-  <article class="py-5 bg-white flex flex-col gap-3 min-w-0">
+  <article class="py-4 bg-white flex flex-col gap-3 min-w-0">
     <header class="px-4 sm:px-6">
-      <h1
-        class="text-xl leading-tight font-bold mb-4 break-words sm:text-2xl"
-        :class="hasTitleMarginRight ? 'mr-36 sm:mr-60' : ''"
-      >
+      <h1 class="text-xl leading-tight font-bold mb-4 break-words sm:text-2xl">
         {{ title }}
       </h1>
       <dl class="mb-3 flex flex-col gap-2">


### PR DESCRIPTION
Fix #282 

## Summary

調整議程詳情 modal 的標題與操作按鈕版面，讓兩者分列顯示，避免長標題與按鈕互相擠壓。

## Changes

- 將分享、收藏與關閉按鈕移至標題上方的獨立列。
- 移除議程標題為操作按鈕預留的右側邊距。

| 電腦版 | 手機板 |
| ---- | ---- |
| <img width="1874" height="921" alt="1784080874870" src="https://github.com/user-attachments/assets/558514df-bb89-439c-9947-950311185afd" /> | <img width="431" height="766" alt="1784080871840" src="https://github.com/user-attachments/assets/c9fd15a7-84d8-4457-81af-b35aaa700030" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved the session detail modal layout for share, favorite, and close controls.
  - Adjusted session information card spacing for a more consistent header appearance.
  - Simplified title styling and removed unnecessary spacing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->