### PR TITLE
fix: render session abstracts and speaker bios with prose styling

### DIFF
--- a/app/components/feature/CpSessionInfoCard.vue
+++ b/app/components/feature/CpSessionInfoCard.vue
@@ -141,11 +141,10 @@ const speakerNames = computed(() =>
       <h2 class="text-lg font-bold my-2">
         {{ t("abstract") }}
       </h2>
-      <div
-        class="text-gray-700 leading-relaxed whitespace-pre-wrap break-words"
-      >
-        <MDC :value="description" />
-      </div>
+      <MDC
+        class="max-w-full break-words prose prose-zinc prose-sm"
+        :value="description"
+      />
     </section>
     <section class="px-4 sm:px-6">
       <h2 class="text-lg font-bold my-2">
@@ -183,11 +182,10 @@ const speakerNames = computed(() =>
                   {{ speaker.name }}
                 </h3>
               </div>
-              <div
-                class="text-sm text-gray-700 leading-relaxed whitespace-pre-wrap break-words"
-              >
-                <MDC :value="speaker.bio" />
-              </div>
+              <MDC
+                class="max-w-full break-words prose prose-zinc prose-sm"
+                :value="speaker.bio"
+              />
             </div>
           </div>
         </div>


### PR DESCRIPTION
Fix #274

CpSessionInfoCard 中的 MDC 組件加入 Markdown 樣式

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved formatting and visual consistency for event abstracts and speaker biographies.
  * Rich text content now uses standardized prose styling for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->