### PR TITLE
perf: load session table data from shared client-side endpoint

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -2,7 +2,7 @@
 import { prerenderRoutes } from 'nuxt/app'
 import { useSecretFeature } from '~/secrets/useSecretFeature'
 
-prerenderRoutes(['/api/opass.json'])
+prerenderRoutes(['/api/opass.json', '/api/session'])
 useSecretFeature()
 
 const route = useRoute()

--- a/app/components/feature/CpSessionLoadingSkeleton.vue
+++ b/app/components/feature/CpSessionLoadingSkeleton.vue
@@ -1,0 +1,21 @@
+<template>
+  <div class="flex flex-col">
+    <!-- DaySelector -->
+    <div class="px-6 pb-4 pt-3 flex w-[var(--viewport-width,100vw)] justify-center order-last sm:order-none">
+      <div class="rounded-full bg-gray-200 h-12 w-1/2 animate-pulse" />
+    </div>
+
+    <!-- FilterBar -->
+    <div class="p-4 flex flex-col gap-3 w-[var(--viewport-width,100vw)] items-stretch sm:flex-row sm:items-center sm:left-0 sm:justify-between sm:sticky sm:z-sticky">
+      <div class="flex shrink-0 gap-3 items-center justify-center sm:justify-start">
+        <div class="rounded-md bg-gray-200 h-12 w-18 animate-pulse sm:h-9" />
+        <div class="rounded-md bg-gray-200 h-12 w-18 animate-pulse sm:h-9" />
+      </div>
+
+      <div class="rounded-md bg-gray-200 h-12 w-full animate-pulse sm:flex-none sm:h-9 sm:w-80" />
+    </div>
+
+    <!-- Session -->
+    <div class="rounded-xl bg-gray-200 h-screen w-[var(--viewport-width,100vw)] animate-pulse" />
+  </div>
+</template>

--- a/app/pages/session.vue
+++ b/app/pages/session.vue
@@ -29,8 +29,9 @@ type SessionsByDay = Record<string, SessionSummary[]>
 
 const SessionsByDaySchema = z.record(z.string(), z.array(SessionSummarySchema))
 
-function parseSessionsByDay(value: unknown): SessionsByDay {
-  const parsed = typeof value === 'string' ? JSON.parse(value) as unknown : value
+async function parseSessionsByDay(value: unknown): Promise<SessionsByDay> {
+  const response = value instanceof Blob ? await value.text() : value
+  const parsed = typeof response === 'string' ? JSON.parse(response) as unknown : response
   return SessionsByDaySchema.parse(parsed)
 }
 

--- a/app/pages/session.vue
+++ b/app/pages/session.vue
@@ -4,7 +4,9 @@ import type { TableViewMode } from '~/components/feature/CpSessionFilterBar.vue'
 import { useStorage } from '@vueuse/core'
 import { prerenderRoutes } from 'nuxt/app'
 import { useI18n } from 'vue-i18n'
+import { z } from 'zod'
 import { useRoute, useRouter } from '#imports'
+import { SessionSummarySchema } from '#shared/types/session'
 import CpFavoriteImportBanner from '~/components/feature/CpFavoriteImportBanner.vue'
 import CpSessionDaySelector from '~/components/feature/CpSessionDaySelector.vue'
 import CpSessionEmptyBanner from '~/components/feature/CpSessionEmptyBanner.vue'
@@ -23,8 +25,19 @@ const { locale, t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 
+type SessionsByDay = Record<string, SessionSummary[]>
+
+const SessionsByDaySchema = z.record(z.string(), z.array(SessionSummarySchema))
+
+function parseSessionsByDay(value: unknown): SessionsByDay {
+  const parsed = typeof value === 'string' ? JSON.parse(value) as unknown : value
+  return SessionsByDaySchema.parse(parsed)
+}
+
 const { data, status } = await useFetch('/api/session', {
   server: false,
+  transform: parseSessionsByDay,
+  default: (): SessionsByDay => ({}),
 })
 const isSessionLoading = computed(() => status.value === 'idle' || status.value === 'pending')
 const { isFavorite, setFavorites, favorites } = provideFavorites()

--- a/app/pages/session.vue
+++ b/app/pages/session.vue
@@ -40,6 +40,7 @@ const { data, status } = await useFetch('/api/session', {
   default: (): SessionsByDay => ({}),
 })
 const isSessionLoading = computed(() => status.value === 'idle' || status.value === 'pending')
+const isSessionLoaded = computed(() => status.value === 'success')
 const { isFavorite, setFavorites, favorites } = provideFavorites()
 
 const days = computed(() => Object.keys(data?.value ?? {}).sort())
@@ -101,6 +102,10 @@ const selectedDay = computed({
 })
 
 watchEffect(() => {
+  if (!isSessionLoaded.value) {
+    return
+  }
+
   if (route.query.day && !queryDay.value) {
     const nextQuery = { ...route.query }
     delete nextQuery.day

--- a/app/pages/session.vue
+++ b/app/pages/session.vue
@@ -34,10 +34,11 @@ function parseSessionsByDay(value: unknown): SessionsByDay {
   return SessionsByDaySchema.parse(parsed)
 }
 
-const { data, status } = await useFetch('/api/session', {
+const { data, status } = useFetch('/api/session', {
   server: false,
   transform: parseSessionsByDay,
   default: (): SessionsByDay => ({}),
+  lazy: true,
 })
 const isSessionLoading = computed(() => status.value === 'idle' || status.value === 'pending')
 const isSessionLoaded = computed(() => status.value === 'success')

--- a/app/pages/session.vue
+++ b/app/pages/session.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { SessionSummary } from '#shared/types/session'
 import type { TableViewMode } from '~/components/feature/CpSessionFilterBar.vue'
 import { useStorage } from '@vueuse/core'
 import { prerenderRoutes } from 'nuxt/app'
@@ -9,6 +10,7 @@ import CpSessionDaySelector from '~/components/feature/CpSessionDaySelector.vue'
 import CpSessionEmptyBanner from '~/components/feature/CpSessionEmptyBanner.vue'
 import CpSessionFilterBar from '~/components/feature/CpSessionFilterBar.vue'
 import CpSessionList from '~/components/feature/CpSessionList.vue'
+import CpSessionLoadingSkeleton from '~/components/feature/CpSessionLoadingSkeleton.vue'
 import CpSessionShareButton from '~/components/feature/CpSessionShareButton.vue'
 import CpSessionTable from '~/components/feature/CpSessionTable.vue'
 import CpSessionTrackTable from '~/components/feature/CpSessionTrackTable.vue'
@@ -21,7 +23,10 @@ const { locale, t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 
-const { data } = await useFetch('/api/session')
+const { data, status } = await useFetch('/api/session', {
+  server: false,
+})
+const isSessionLoading = computed(() => status.value === 'idle' || status.value === 'pending')
 const { isFavorite, setFavorites, favorites } = provideFavorites()
 
 const days = computed(() => Object.keys(data?.value ?? {}).sort())
@@ -156,11 +161,14 @@ function importShared() {
   view.value = 'favorite'
 }
 
-prerenderRoutes(
-  Object.values(data.value ?? {})
-    .flat()
-    .map((s) => `/session/${s.id}`),
-)
+if (import.meta.server && !route.params.id) {
+  const sessionsByDay = await $fetch<Record<string, SessionSummary[]>>('/api/session')
+  prerenderRoutes(
+    Object.values(sessionsByDay)
+      .flat()
+      .map((s) => `/session/${s.id}`),
+  )
+}
 
 useSeoMeta({
   title: () => t('meta.title'),
@@ -182,28 +190,12 @@ definePageMeta({
 
     <ClientOnly>
       <template #fallback>
-        <div class="flex flex-col">
-          <!-- DaySelector -->
-          <div class="px-6 pb-4 pt-3 flex w-[var(--viewport-width,100vw)] justify-center order-last sm:order-none">
-            <div class="rounded-full bg-gray-200 h-12 w-1/2 animate-pulse" />
-          </div>
-
-          <!-- FilterBar -->
-          <div class="p-4 flex flex-col gap-3 w-[var(--viewport-width,100vw)] items-stretch sm:flex-row sm:items-center sm:left-0 sm:justify-between sm:sticky sm:z-sticky">
-            <div class="flex shrink-0 gap-3 items-center justify-center sm:justify-start">
-              <div class="rounded-md bg-gray-200 h-12 w-18 animate-pulse sm:h-9" />
-              <div class="rounded-md bg-gray-200 h-12 w-18 animate-pulse sm:h-9" />
-            </div>
-
-            <div class="rounded-md bg-gray-200 h-12 w-full animate-pulse sm:flex-none sm:h-9 sm:w-80" />
-          </div>
-
-          <!-- Session -->
-          <div class="rounded-xl bg-gray-200 h-screen w-[var(--viewport-width,100vw)] animate-pulse" />
-        </div>
+        <CpSessionLoadingSkeleton />
       </template>
 
-      <template v-if="selectedDay">
+      <CpSessionLoadingSkeleton v-if="isSessionLoading" />
+
+      <template v-else-if="selectedDay">
         <div class="flex flex-col">
           <!-- A `?filter=` link carries shared favorites: preview them and offer import. -->
           <div


### PR DESCRIPTION
## Summary

將完整議程 table 資料改為由 client 端透過共用的靜態 `/api/session` 載入，避免每個 `/session/<id>` 頁的 `_payload.json` 都重複包含整份 session 資料。同時保留 SSG 產生 session detail 靜態頁的能力，確保 GitHub Pages 部署後仍可直接開啟 detail URL。

## Changes

- 將 `app/pages/session.vue` 的完整議程資料改為 `server: false`，讓 table 資料只在 client 端請求。
- 在 SSG 階段另外透過 `$fetch('/api/session')` 取得 session 清單，只用來註冊 `/session/<id>` prerender routes。
- 在 `app/app.vue` 明確加入 `/api/session` prerender，確保靜態部署時 client 可請求 session JSON。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a session loading skeleton to improve perceived performance while data loads.
  * Extended prerendering support to include `/api/session` and generate session detail routes when applicable.

* **Bug Fixes**
  * Updated the session page to reliably load and gate rendering with clear loading states.
  * Added response validation/normalization so session data is structured consistently before use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->