### PR TITLE
fix: prioritize main session track

### DIFF
--- a/app/components/feature/CpSessionTrackTable.vue
+++ b/app/components/feature/CpSessionTrackTable.vue
@@ -5,7 +5,7 @@ import { useI18n } from 'vue-i18n'
 import { useDragScroll } from '~/composables/useDragScroll'
 import { useFavoriteLabel, useFavorites } from '~/composables/useFavorites'
 import { useRealtime } from '~/composables/useRealtime'
-import { DEFAULT_TRACK_COLOR, NO_TRACK } from '~/utils/tracks'
+import { DEFAULT_TRACK_COLOR, isMainTrack, NO_TRACK } from '~/utils/tracks'
 
 const { sessions: _sessions, trackColors, day, timeRange, interval, rowHeight, columnWidth, preview = false } = defineProps<{
   day: string
@@ -78,12 +78,6 @@ const daySessions = computed(() =>
   (_sessions ?? []).filter((session) => session.start?.startsWith(day) && session.end),
 )
 
-// Match by name (either locale) since Pretalx track ids aren't stable across events.
-const MAIN_TRACK_NAMES = ['主議程', 'Main Session Track']
-function isMainTrack(name?: SessionTrack['name']) {
-  return MAIN_TRACK_NAMES.includes(name?.['zh-hant'] ?? '') || MAIN_TRACK_NAMES.includes(name?.en ?? '')
-}
-
 // Shared with CpSessionTable: both pin by English room code so switching views keeps pins in sync.
 // null = never visited (pin main by default); [] = user unpinned everything (respect it).
 const pinnedRooms = useLocalStorage<string[] | null>('coscup-pinned-rooms', null, {
@@ -136,7 +130,7 @@ const tracks = computed(() => {
     .sort((a, b) => {
       const bestA = bestRoomByTrackId.get(a.trackId) ?? ''
       const bestB = bestRoomByTrackId.get(b.trackId) ?? ''
-      return compareRooms(bestA, bestB) || compareRooms(a.roomEn, b.roomEn)
+      return Number(b.isMain) - Number(a.isMain) || compareRooms(bestA, bestB) || compareRooms(a.roomEn, b.roomEn)
     })
     .map((track) => ({ ...track, color: trackColors.get(track.trackId ?? NO_TRACK) ?? DEFAULT_TRACK_COLOR }))
     .sort((a, b) => {

--- a/shared/utils/tracks.ts
+++ b/shared/utils/tracks.ts
@@ -37,9 +37,10 @@ export function trackKey(session: SessionSummary): string {
 }
 
 // Match by name (either locale) since Pretalx track ids aren't stable across events.
-const MAIN_TRACK_NAMES = ['主議程', 'Main Session Track']
 export function isMainTrack(name?: SessionTrack['name']): boolean {
-  return MAIN_TRACK_NAMES.includes(name?.['zh-hant'] ?? '') || MAIN_TRACK_NAMES.includes(name?.en ?? '')
+  const zhName = name?.['zh-hant'] ?? ''
+  const enName = name?.en ?? ''
+  return zhName.includes('主議程軌') || enName.includes('Main Session Track')
 }
 
 /**


### PR DESCRIPTION
Closes #265 

## Summary

調整議程軌時間表的排序，讓主議程軌在未釘選時優先顯示。
同時將主議程判斷集中至共用工具，確保兩種議程視圖使用一致規則。

## Changes

- 在議程軌排序中優先排列主議程。
- 更新共用 isMainTrack，支援辨識「主議程軌」及英文主議程名稱。
- 移除 CpSessionTrackTable 內重複的主議程判斷，改由共用工具匯入。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of main session tracks across Traditional Chinese and English names, including names with additional descriptive text.
  * Main session tracks are now consistently displayed before other tracks in session listings.
  * Track ordering is more reliable when room or venue information varies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->