### PR TITLE
feat: show RB/AU floor plan first on venue page

### DIFF
--- a/app/pages/venue.vue
+++ b/app/pages/venue.vue
@@ -29,11 +29,11 @@ const overviewImage = [
 ]
 
 const floorImages = [
+  { key: 'RBAU', alt: 'RB/AU', src: rbau },
   { key: 'TR2F', alt: 'TR 2F', src: tr2f },
   { key: 'TR3F', alt: 'TR 3F', src: tr3f },
   { key: 'TR4F', alt: 'TR 4F', src: tr4f },
   { key: 'TR5F', alt: 'TR 5F', src: tr5f },
-  { key: 'RBAU', alt: 'RB/AU', src: rbau },
 ]
 
 const boothImages = [


### PR DESCRIPTION
將會場地圖頁面「樓層平面圖」分頁中的 RB/AU 平面圖移到第一張，原本排在 TR 2F–5F 之後的最後一張。

需求來自 Mattermost：https://chat.coscup.org/coscup/pl/yactysn6z38kmn7wg1unxqeq6c

> 要麻煩資訊組，幫忙將 「樓層平面圖」的「RB」作為第一個張（現在是最後一張圖），謝謝
> https://coscup.org/2026/venue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the display order of venue floor images so the RB/AU image appears before the TR2F–TR5F images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->