### PR TITLE
fix: use defined theme tokens on landing cards

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -167,14 +167,14 @@ useSeoMeta({
         </article>
 
         <article class="p-6 border border-gray-200 rounded-lg bg-white flex flex-col gap-4 shadow-sm">
-          <h2 class="text-xl text-landing-green font-semibold m-0">
+          <h2 class="text-xl text-cp-primary font-semibold m-0">
             {{ t('attendee_survey.title') }}
           </h2>
           <p class="text-gray-700 leading-relaxed m-0">
             {{ t('attendee_survey.desc') }}
           </p>
           <NuxtLink
-            class="text-white mt-auto px-4 py-2 rounded bg-cp-green w-max shadow-sm hover:shadow-md"
+            class="text-white mt-auto px-4 py-2 rounded bg-cp-secondary w-max shadow-sm hover:shadow-md"
             :to="t('attendee_survey.link')"
           >
             {{ t('attendee_survey.link_text') }}
@@ -182,7 +182,7 @@ useSeoMeta({
         </article>
 
         <article class="p-6 border border-gray-200 rounded-lg bg-white flex flex-col gap-4 shadow-sm">
-          <h2 class="text-xl text-landing-green font-semibold m-0">
+          <h2 class="text-xl text-cp-primary font-semibold m-0">
             {{ t('how_to_enjoy.title') }}
           </h2>
           <p class="text-gray-700 leading-relaxed m-0">


### PR DESCRIPTION
## What

Three class fixes on the landing page cards in `app/pages/index.vue`:

- `bg-cp-green` → `bg-cp-secondary` on the attendee survey button
- `text-landing-green` → `text-cp-primary` on the attendee survey and how-to-enjoy headings

## Why

#309 removed `cp-green` but missed this button, so it renders with no background. `text-landing-green` was never defined in `uno.config.ts`, so those headings render unstyled. Both replacements match the donate card in the same grid.

## Testing

`pnpm lint` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated attendee survey card styling to use the shared primary color scheme.
  * Refined the survey link button and following card heading for consistent visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->