### PR TITLE
fix: calculate track day from conference start date

### DIFF
--- a/app/pages/track/[id].vue
+++ b/app/pages/track/[id].vue
@@ -27,6 +27,7 @@ const { data: ad } = await useFetch<Ad[]>('/api/ad')
 
 provideFavorites()
 
+const CONFERENCE_START_DAY = '2026-08-08'
 const localeKey = computed(() => (locale.value === 'zh' ? 'zh' : 'en'))
 const meta = computed(() => getTrackMeta(Number(route.params.id)))
 
@@ -109,8 +110,13 @@ function closeSession() {
 }
 
 const dayIndex = computed(() => {
-  const idx = days.value.indexOf(selectedDay.value)
-  return idx >= 0 ? idx + 1 : 1
+  if (!selectedDay.value) {
+    return 1
+  }
+
+  const start = new Date(`${CONFERENCE_START_DAY}T00:00:00+08:00`)
+  const selected = new Date(`${selectedDay.value}T00:00:00+08:00`)
+  return Math.round((selected.getTime() - start.getTime()) / 86_400_000) + 1
 })
 
 const dayRooms = computed(() => {


### PR DESCRIPTION
closes #315 

## Summary

修正僅在活動第二天有議程的 track，會被錯誤標示為「Day 1」的問題。Day 編號現在依 COSCUP 2026 的會期首日計算，而非依該 track 自身的日期列表排序。

## Changes

- 在 track 頁面定義會期首日 2026-08-08。
- 以選取日期與會期首日的日曆差計算 Day 編號。
- 保留未選取日期時顯示 Day 1 的既有預設行為。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected conference day selection to align with the calendar date.
  * Defaults to the first conference day when no day is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->