### PR TITLE
fix: use theme green for active session controls

### DIFF
--- a/app/components/shared/CpButton.vue
+++ b/app/components/shared/CpButton.vue
@@ -25,7 +25,7 @@ const variantClasses = computed(() => {
   }
 
   return props.active
-    ? 'bg-cp-secondary/8 text-cp-accent'
+    ? 'bg-cp-secondary/8 text-cp-primary'
     : 'bg-transparent text-gray-500 hover:enabled:bg-gray-200 active:enabled:bg-gray-300'
 })
 </script>


### PR DESCRIPTION
 將 session 頁面切換控制項的啟用文字色由藍色改為專案主題深綠色

<img width="1317" height="915" alt="image" src="https://github.com/user-attachments/assets/e4abdf8f-1676-4c17-b11f-1ef3e6f396ea" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the active-state text color for basic buttons to use the primary color for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->